### PR TITLE
fix(db): harden sqlite for concurrent scheduler load

### DIFF
--- a/internal/db/busy.go
+++ b/internal/db/busy.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// SQLite result codes for transient lock contention. Declared locally so this
+// package does not take a hard dependency on the driver's internal lib package;
+// they are stable, standard SQLite codes.
+const (
+	sqliteBusy   = 5 // SQLITE_BUSY: the database file is locked.
+	sqliteLocked = 6 // SQLITE_LOCKED: a table in the database is locked.
+)
+
+// IsBusy reports whether err is a transient SQLite contention error
+// (SQLITE_BUSY / SQLITE_LOCKED) that is safe to retry. It matches any error
+// exposing a `Code() int` method (modernc.org/sqlite's *Error does), so it
+// needs no import of the driver package. MySQL never produces these codes, so
+// shared write paths can be wrapped unconditionally without affecting MySQL.
+func IsBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var coder interface{ Code() int }
+	if errors.As(err, &coder) {
+		switch coder.Code() {
+		case sqliteBusy, sqliteLocked:
+			return true
+		}
+	}
+	return false
+}
+
+// RetryOnBusy runs fn, retrying a few times with a short escalating backoff
+// while it returns a transient SQLite busy/locked error. The busy_timeout pragma
+// already makes the driver wait for contended locks, so this is defense-in-depth
+// for the rare residual case (e.g. a WAL checkpoint racing a write) rather than
+// the primary fix. For non-busy errors it returns immediately, and because
+// IsBusy never matches MySQL errors it is a transparent passthrough there.
+func RetryOnBusy(ctx context.Context, fn func() error) error {
+	const maxAttempts = 4
+
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err = fn(); !IsBusy(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(time.Duration(attempt+1) * 25 * time.Millisecond):
+		}
+	}
+	return err
+}

--- a/internal/db/concurrency_test.go
+++ b/internal/db/concurrency_test.go
@@ -1,0 +1,133 @@
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Ho3einK84/Nodexia/internal/config"
+	"github.com/Ho3einK84/Nodexia/internal/db"
+)
+
+// TestSQLiteConcurrentWritesAndReads reproduces the scheduler-vs-HTTP contention
+// that previously surfaced as "database is locked (5) (SQLITE_BUSY)". Many
+// goroutines run replace-latest style write transactions (DELETE + INSERT, like
+// nodes.ReplaceLatest) while others read concurrently, all through a runtime
+// opened by db.Open so the real DSN pragmas and pool sizing are exercised.
+//
+// With WAL + busy_timeout + the single-writer SQLite pool this completes without
+// any busy/locked error. Under the previous configuration — a bare file-path DSN
+// (rollback journal, no busy_timeout) with MaxOpenConns=10 — it fails
+// intermittently, so this test would have caught the regression.
+func TestSQLiteConcurrentWritesAndReads(t *testing.T) {
+	cfg := config.DatabaseConfig{
+		Driver:     config.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), "concurrency.sqlite3"),
+		// Deliberately request the old, contention-prone pool size to prove the
+		// sqlite dialect overrides it to a single writer.
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 5 * time.Minute,
+	}
+
+	runtime, err := db.Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer runtime.Close()
+
+	ctx := context.Background()
+	if _, err := runtime.SQL.ExecContext(ctx, `CREATE TABLE latest_snapshots (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		server_id INTEGER NOT NULL,
+		payload TEXT NOT NULL,
+		created_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	const (
+		writers      = 8
+		readers      = 8
+		iterations   = 40
+		bufferedSlot = (writers + readers)
+	)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, bufferedSlot)
+	start := make(chan struct{})
+
+	// Writers: scheduler-style replace-latest transactions, each owning its own
+	// server_id so they continually delete and re-insert the same row set.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(serverID int64) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				if err := replaceLatest(ctx, runtime.SQL, serverID, i); err != nil {
+					errCh <- fmt.Errorf("writer %d iter %d: %w", serverID, i, err)
+					return
+				}
+			}
+		}(int64(w))
+	}
+
+	// Readers: concurrent dashboard-style reads against the same table.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < iterations; i++ {
+				var count int
+				if err := runtime.SQL.QueryRowContext(ctx, `SELECT COUNT(*) FROM latest_snapshots`).Scan(&count); err != nil {
+					errCh <- fmt.Errorf("reader iter %d: %w", i, err)
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if db.IsBusy(err) {
+			t.Fatalf("hit SQLite busy/locked under concurrency (the bug): %v", err)
+		}
+		t.Fatalf("unexpected error under concurrency: %v", err)
+	}
+}
+
+// replaceLatest mirrors nodes.ReplaceLatest: a single write transaction that
+// clears the server's rows and inserts a fresh one.
+func replaceLatest(ctx context.Context, conn *sql.DB, serverID int64, n int) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM latest_snapshots WHERE server_id = ?`, serverID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO latest_snapshots (server_id, payload, created_at) VALUES (?, ?, ?)`,
+		serverID,
+		fmt.Sprintf("payload-%d", n),
+		time.Now().UTC().Format(time.RFC3339Nano),
+	); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/internal/db/driver.go
+++ b/internal/db/driver.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +17,10 @@ type Dialect interface {
 	DriverName() string
 	DataSourceName(cfg config.DatabaseConfig) (string, error)
 	Prepare(cfg config.DatabaseConfig) error
+	// ConfigurePool applies dialect-appropriate connection-pool limits. SQLite
+	// and MySQL want very different sizing, so the decision lives with the
+	// dialect rather than in shared bootstrap code.
+	ConfigurePool(conn *sql.DB, cfg config.DatabaseConfig)
 }
 
 type sqliteDialect struct{}
@@ -33,7 +39,50 @@ func (sqliteDialect) DataSourceName(cfg config.DatabaseConfig) (string, error) {
 		return "", errors.New("db: sqlite path cannot be empty")
 	}
 
-	return filepath.Clean(path), nil
+	// Connection pragmas are encoded into the DSN so modernc.org/sqlite applies
+	// them to EVERY connection the pool opens. The driver runs each `_pragma`
+	// value as a `PRAGMA ...` statement inside newConn on every Open (see
+	// applyQueryParams), which side-steps the classic database/sql footgun where
+	// a one-off `PRAGMA` only configures whichever connection happened to run it.
+	params := url.Values{}
+	// busy_timeout: wait up to 5s for a contended lock instead of failing
+	// immediately with SQLITE_BUSY. This is what lets a background scheduler
+	// write queue behind an in-flight HTTP write rather than erroring and
+	// cascading into HTTP 500s.
+	params.Add("_pragma", "busy_timeout(5000)")
+	// WAL: readers no longer block on the single writer (and vice versa), so
+	// HTTP dashboard reads run concurrently with the scheduler's writes.
+	params.Add("_pragma", "journal_mode(WAL)")
+	// synchronous=NORMAL is the journal mode WAL is designed for: durable across
+	// an application crash, with only the most recent transaction at risk on an
+	// OS/power-level crash — a sound trade for a control panel and much cheaper
+	// than FULL's per-commit fsync.
+	params.Add("_pragma", "synchronous(NORMAL)")
+	// foreign_keys: SQLite disables FK enforcement per-connection by default;
+	// keep it on (previously handled by a global connection hook).
+	params.Add("_pragma", "foreign_keys(ON)")
+	// _txlock=immediate begins write transactions with BEGIN IMMEDIATE so the
+	// busy_timeout handler covers lock acquisition. A DEFERRED transaction that
+	// starts reading and later upgrades to a write returns SQLITE_BUSY
+	// immediately (the busy handler is skipped to avoid deadlock) — the subtle
+	// reason WAL + busy_timeout alone are not enough for the scheduler's
+	// DELETE+INSERT replace transactions.
+	params.Set("_txlock", "immediate")
+
+	return filepath.Clean(path) + "?" + params.Encode(), nil
+}
+
+// ConfigurePool pins SQLite to a single connection. SQLite serializes writes at
+// the database level, so opening many connections only manufactures
+// writer-vs-writer contention — the exact SQLITE_BUSY failures this addresses.
+// A single connection lets database/sql queue all access in-process so writes
+// never collide, while WAL (set in the DSN) keeps reads off the writer's lock.
+// The connection is kept warm (no idle eviction, no max lifetime) so the WAL and
+// pragma setup is paid once rather than on every reconnect.
+func (sqliteDialect) ConfigurePool(conn *sql.DB, _ config.DatabaseConfig) {
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+	conn.SetConnMaxLifetime(0)
 }
 
 func (sqliteDialect) Prepare(cfg config.DatabaseConfig) error {
@@ -71,6 +120,14 @@ func (mysqlDialect) DataSourceName(cfg config.DatabaseConfig) (string, error) {
 
 func (mysqlDialect) Prepare(config.DatabaseConfig) error {
 	return nil
+}
+
+// ConfigurePool applies the configured pool sizing. MySQL handles concurrent
+// connections natively, so its pool behaviour is left exactly as configured.
+func (mysqlDialect) ConfigurePool(conn *sql.DB, cfg config.DatabaseConfig) {
+	conn.SetMaxOpenConns(cfg.MaxOpenConns)
+	conn.SetMaxIdleConns(cfg.MaxIdleConns)
+	conn.SetConnMaxLifetime(cfg.ConnMaxLifetime)
 }
 
 func ResolveDialect(driver string) (Dialect, error) {

--- a/internal/db/imports.go
+++ b/internal/db/imports.go
@@ -1,17 +1,10 @@
 package db
 
 import (
-	"context"
-
+	// Register the database/sql drivers. SQLite connection setup (WAL,
+	// busy_timeout, foreign_keys, …) is applied per-connection via the DSN built
+	// in the sqlite dialect's DataSourceName, so no global connection hook is
+	// needed here.
 	_ "github.com/go-sql-driver/mysql"
-	sqlite "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
-
-func init() {
-	// Enable foreign-key enforcement on every SQLite connection.
-	// Without this, SQLite silently ignores all FK constraints.
-	sqlite.RegisterConnectionHook(func(conn sqlite.ExecQuerierContext, _ string) error {
-		_, err := conn.ExecContext(context.Background(), "PRAGMA foreign_keys = ON", nil)
-		return err
-	})
-}

--- a/internal/db/pragma_test.go
+++ b/internal/db/pragma_test.go
@@ -1,0 +1,62 @@
+package db_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Ho3einK84/Nodexia/internal/config"
+	"github.com/Ho3einK84/Nodexia/internal/db"
+)
+
+// TestSQLitePragmasApplied verifies the DSN-encoded pragmas actually take effect
+// on a live pooled connection. This is the guard against the common footgun of
+// "thinking" WAL/busy_timeout are on when the DSN was built wrong — the assertion
+// reads them back from the database rather than trusting the configuration.
+func TestSQLitePragmasApplied(t *testing.T) {
+	cfg := config.DatabaseConfig{
+		Driver:     config.DriverSQLite,
+		SQLitePath: filepath.Join(t.TempDir(), "pragmas.sqlite3"),
+	}
+
+	runtime, err := db.Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer runtime.Close()
+
+	ctx := context.Background()
+
+	var journalMode string
+	if err := runtime.SQL.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var busyTimeout int
+	if err := runtime.SQL.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", busyTimeout)
+	}
+
+	var foreignKeys int
+	if err := runtime.SQL.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+		t.Fatalf("read foreign_keys: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Fatalf("foreign_keys = %d, want 1", foreignKeys)
+	}
+
+	var synchronous int
+	if err := runtime.SQL.QueryRowContext(ctx, "PRAGMA synchronous").Scan(&synchronous); err != nil {
+		t.Fatalf("read synchronous: %v", err)
+	}
+	if synchronous != 1 { // 1 == NORMAL
+		t.Fatalf("synchronous = %d, want 1 (NORMAL)", synchronous)
+	}
+}

--- a/internal/db/runtime.go
+++ b/internal/db/runtime.go
@@ -35,9 +35,7 @@ func Open(ctx context.Context, cfg config.DatabaseConfig) (*Runtime, error) {
 		return nil, fmt.Errorf("db: open connection: %w", err)
 	}
 
-	conn.SetMaxOpenConns(cfg.MaxOpenConns)
-	conn.SetMaxIdleConns(cfg.MaxIdleConns)
-	conn.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	dialect.ConfigurePool(conn, cfg)
 
 	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/scheduler/runtime.go
+++ b/internal/scheduler/runtime.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Ho3einK84/Nodexia/internal/config"
+	"github.com/Ho3einK84/Nodexia/internal/db"
 	"github.com/Ho3einK84/Nodexia/internal/module/alerts"
 	"github.com/Ho3einK84/Nodexia/internal/module/analytics"
 	"github.com/Ho3einK84/Nodexia/internal/module/monitoring"
@@ -544,7 +545,10 @@ func (r *Runtime) executeMonitoringJob(ctx context.Context, server servers.Serve
 		return "", err
 	}
 	snapshot.ServerID = server.ID
-	if _, err := r.monitorRepo.Append(ctx, snapshot); err != nil {
+	if err := db.RetryOnBusy(ctx, func() error {
+		_, appendErr := r.monitorRepo.Append(ctx, snapshot)
+		return appendErr
+	}); err != nil {
 		return "", err
 	}
 
@@ -559,7 +563,10 @@ func (r *Runtime) executeMonitoringJob(ctx context.Context, server servers.Serve
 	trafficStored := false
 	if trafficErr == nil {
 		trafficSnapshot.ServerID = server.ID
-		if _, err := r.trafficRepo.AppendTraffic(ctx, trafficSnapshot); err == nil {
+		if err := db.RetryOnBusy(ctx, func() error {
+			_, appendErr := r.trafficRepo.AppendTraffic(ctx, trafficSnapshot)
+			return appendErr
+		}); err == nil {
 			trafficStored = true
 		}
 	}
@@ -627,7 +634,9 @@ func (r *Runtime) executeNodesJob(ctx context.Context, server servers.Server, re
 	}
 
 	collectedAt := latestNodesCollectedAt(snapshots, probes)
-	if err := r.nodeRepo.ReplaceLatest(ctx, server.ID, snapshots, collectedAt); err != nil {
+	if err := db.RetryOnBusy(ctx, func() error {
+		return r.nodeRepo.ReplaceLatest(ctx, server.ID, snapshots, collectedAt)
+	}); err != nil {
 		return "", err
 	}
 	if len(snapshots) == 0 {


### PR DESCRIPTION
Open SQLite with WAL, busy_timeout, synchronous=NORMAL, foreign_keys and immediate txlock via the DSN so every pooled connection gets them, and pin the pool to a single writer connection. MySQL pool behaviour is unchanged. Add busy-retry as defense-in-depth on scheduler writes plus concurrent read/write tests that reproduce the SQLITE_BUSY bug.

https://claude.ai/code/session_016pNJqs6t8mKTtDGqqci8sz