### PR TITLE
feat(servers): detect and badge node country flags

### DIFF
--- a/internal/geoip/countries.go
+++ b/internal/geoip/countries.go
@@ -1,0 +1,36 @@
+package geoip
+
+import "strings"
+
+// countryNames maps every ISO 3166-1 alpha-2 code to its English name. It is the
+// recognised-country allow-list used by ParseResponse / FlagEmoji / CountryName.
+//
+// To keep the source compact (and avoid one enormous map literal), the data is
+// stored as "CC=Name" pairs joined by "|" across a handful of region segments
+// and parsed once at init. Editing is a matter of adding a pair to the relevant
+// segment.
+var countryNames = parseCountryData(
+	countryDataAF + "|" +
+		countryDataAM + "|" +
+		countryDataAS + "|" +
+		countryDataEU + "|" +
+		countryDataOC,
+)
+
+func parseCountryData(data string) map[string]string {
+	pairs := strings.Split(data, "|")
+	out := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		code, name, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		code = strings.ToUpper(strings.TrimSpace(code))
+		name = strings.TrimSpace(name)
+		if code == "" || name == "" {
+			continue
+		}
+		out[code] = name
+	}
+	return out
+}

--- a/internal/geoip/countries_af.go
+++ b/internal/geoip/countries_af.go
@@ -1,0 +1,15 @@
+package geoip
+
+// countryDataAF holds African ISO 3166-1 alpha-2 codes and names.
+const countryDataAF = "DZ=Algeria|AO=Angola|BJ=Benin|BW=Botswana|BF=Burkina Faso|" +
+	"BI=Burundi|CV=Cabo Verde|CM=Cameroon|CF=Central African Republic|TD=Chad|" +
+	"KM=Comoros|CG=Congo|CD=Congo (Kinshasa)|CI=Cote d'Ivoire|DJ=Djibouti|" +
+	"EG=Egypt|GQ=Equatorial Guinea|ER=Eritrea|SZ=Eswatini|ET=Ethiopia|" +
+	"GA=Gabon|GM=Gambia|GH=Ghana|GN=Guinea|GW=Guinea-Bissau|" +
+	"KE=Kenya|LS=Lesotho|LR=Liberia|LY=Libya|MG=Madagascar|" +
+	"MW=Malawi|ML=Mali|MR=Mauritania|MU=Mauritius|YT=Mayotte|" +
+	"MA=Morocco|MZ=Mozambique|NA=Namibia|NE=Niger|NG=Nigeria|" +
+	"RE=Reunion|RW=Rwanda|SH=Saint Helena|ST=Sao Tome and Principe|SN=Senegal|" +
+	"SC=Seychelles|SL=Sierra Leone|SO=Somalia|ZA=South Africa|SS=South Sudan|" +
+	"SD=Sudan|TZ=Tanzania|TG=Togo|TN=Tunisia|UG=Uganda|" +
+	"EH=Western Sahara|ZM=Zambia|ZW=Zimbabwe"

--- a/internal/geoip/countries_am.go
+++ b/internal/geoip/countries_am.go
@@ -1,0 +1,14 @@
+package geoip
+
+// countryDataAM holds the Americas ISO 3166-1 alpha-2 codes and names.
+const countryDataAM = "AI=Anguilla|AG=Antigua and Barbuda|AR=Argentina|AW=Aruba|BS=Bahamas|" +
+	"BB=Barbados|BZ=Belize|BM=Bermuda|BO=Bolivia|BQ=Bonaire|" +
+	"BR=Brazil|VG=British Virgin Islands|CA=Canada|KY=Cayman Islands|CL=Chile|" +
+	"CO=Colombia|CR=Costa Rica|CU=Cuba|CW=Curacao|DM=Dominica|" +
+	"DO=Dominican Republic|EC=Ecuador|SV=El Salvador|FK=Falkland Islands|GF=French Guiana|" +
+	"GL=Greenland|GD=Grenada|GP=Guadeloupe|GT=Guatemala|GY=Guyana|" +
+	"HT=Haiti|HN=Honduras|JM=Jamaica|MQ=Martinique|MX=Mexico|" +
+	"MS=Montserrat|NI=Nicaragua|PA=Panama|PY=Paraguay|PE=Peru|" +
+	"PR=Puerto Rico|BL=Saint Barthelemy|KN=Saint Kitts and Nevis|LC=Saint Lucia|MF=Saint Martin|" +
+	"PM=Saint Pierre and Miquelon|VC=Saint Vincent and the Grenadines|SR=Suriname|TT=Trinidad and Tobago|TC=Turks and Caicos Islands|" +
+	"US=United States|UY=Uruguay|VE=Venezuela|VI=U.S. Virgin Islands"

--- a/internal/geoip/countries_as.go
+++ b/internal/geoip/countries_as.go
@@ -1,0 +1,14 @@
+package geoip
+
+// countryDataAS holds Asian and Middle Eastern ISO 3166-1 alpha-2 codes.
+const countryDataAS = "AF=Afghanistan|AM=Armenia|AZ=Azerbaijan|BH=Bahrain|BD=Bangladesh|" +
+	"BT=Bhutan|BN=Brunei|KH=Cambodia|CN=China|CY=Cyprus|" +
+	"GE=Georgia|HK=Hong Kong|IN=India|ID=Indonesia|IR=Iran|" +
+	"IQ=Iraq|IL=Israel|JP=Japan|JO=Jordan|KZ=Kazakhstan|" +
+	"KW=Kuwait|KG=Kyrgyzstan|LA=Laos|LB=Lebanon|MO=Macao|" +
+	"MY=Malaysia|MV=Maldives|MN=Mongolia|MM=Myanmar|NP=Nepal|" +
+	"KP=North Korea|OM=Oman|PK=Pakistan|PS=Palestine|PH=Philippines|" +
+	"QA=Qatar|SA=Saudi Arabia|SG=Singapore|KR=South Korea|LK=Sri Lanka|" +
+	"SY=Syria|TW=Taiwan|TJ=Tajikistan|TH=Thailand|TL=Timor-Leste|" +
+	"TR=Turkey|TM=Turkmenistan|AE=United Arab Emirates|UZ=Uzbekistan|VN=Vietnam|" +
+	"YE=Yemen"

--- a/internal/geoip/countries_eu.go
+++ b/internal/geoip/countries_eu.go
@@ -1,0 +1,14 @@
+package geoip
+
+// countryDataEU holds European ISO 3166-1 alpha-2 codes and names.
+const countryDataEU = "AL=Albania|AD=Andorra|AT=Austria|BY=Belarus|BE=Belgium|" +
+	"BA=Bosnia and Herzegovina|BG=Bulgaria|HR=Croatia|CZ=Czechia|DK=Denmark|" +
+	"EE=Estonia|FO=Faroe Islands|FI=Finland|FR=France|DE=Germany|" +
+	"GI=Gibraltar|GR=Greece|GG=Guernsey|HU=Hungary|IS=Iceland|" +
+	"IE=Ireland|IM=Isle of Man|IT=Italy|JE=Jersey|XK=Kosovo|" +
+	"LV=Latvia|LI=Liechtenstein|LT=Lithuania|LU=Luxembourg|MT=Malta|" +
+	"MD=Moldova|MC=Monaco|ME=Montenegro|NL=Netherlands|MK=North Macedonia|" +
+	"NO=Norway|PL=Poland|PT=Portugal|RO=Romania|RU=Russia|" +
+	"SM=San Marino|RS=Serbia|SK=Slovakia|SI=Slovenia|ES=Spain|" +
+	"SJ=Svalbard and Jan Mayen|SE=Sweden|CH=Switzerland|UA=Ukraine|GB=United Kingdom|" +
+	"VA=Vatican City|AX=Aland Islands"

--- a/internal/geoip/countries_oc.go
+++ b/internal/geoip/countries_oc.go
@@ -1,0 +1,11 @@
+package geoip
+
+// countryDataOC holds Oceania ISO 3166-1 alpha-2 codes plus a few remaining
+// territories that complete the alpha-2 allow-list.
+const countryDataOC = "AS=American Samoa|AU=Australia|CK=Cook Islands|FJ=Fiji|PF=French Polynesia|" +
+	"GU=Guam|KI=Kiribati|MH=Marshall Islands|FM=Micronesia|NR=Nauru|" +
+	"NC=New Caledonia|NZ=New Zealand|NU=Niue|NF=Norfolk Island|MP=Northern Mariana Islands|" +
+	"PW=Palau|PG=Papua New Guinea|WS=Samoa|SB=Solomon Islands|TK=Tokelau|" +
+	"TO=Tonga|TV=Tuvalu|VU=Vanuatu|WF=Wallis and Futuna|" +
+	"AQ=Antarctica|BV=Bouvet Island|IO=British Indian Ocean Territory|CX=Christmas Island|CC=Cocos Islands|" +
+	"TF=French Southern Territories|GS=South Georgia|HM=Heard Island and McDonald Islands|UM=U.S. Minor Outlying Islands"

--- a/internal/geoip/geoip.go
+++ b/internal/geoip/geoip.go
@@ -1,0 +1,104 @@
+// Package geoip detects a server's country from its own public-IP egress and
+// turns the resulting ISO 3166-1 alpha-2 code into a flag emoji.
+//
+// Detection deliberately runs ON the node over the already-established SSH
+// connection (see Command) rather than from the Nodexia panel: a lookup made
+// from the panel would report the panel's IP, not the node's, and the panel's
+// own outbound network may be restricted. Running the probe remotely yields the
+// node's real public IP and therefore its real country.
+//
+// Everything in this package is pure and network-free except for the remote
+// Command string itself — the SSH round-trip is performed by the caller. That
+// keeps parsing/flag logic fully unit-testable without touching the network.
+package geoip
+
+import "strings"
+
+// Command is a POSIX-sh probe run over SSH on the target node. It asks a small
+// set of keyless geo-IP services for the node's ISO 3166-1 alpha-2 country code
+// and prints the first valid one (nothing else) to stdout.
+//
+// Robustness rules baked in:
+//   - Prefer curl, fall back to wget, and exit cleanly (empty stdout) when
+//     neither exists — the caller treats empty output as "no country".
+//   - Each request has its own short timeout so a blocked/slow endpoint cannot
+//     stall the whole probe; the endpoints are tried in order until one answers.
+//   - Only a bare two-letter response is accepted (case "[A-Za-z][A-Za-z]"), so
+//     error pages, JSON, rate-limit notices, or an echoed IP never leak through
+//     as a bogus country.
+//   - No single quotes appear inside the outer sh -c '...' wrapper, matching the
+//     project's convention for generated remote shell.
+//
+// The endpoints all return a bare alpha-2 code (no JSON), which keeps both the
+// shell and ParseResponse simple:
+//   - https://ipinfo.io/country
+//   - https://ifconfig.co/country-iso
+//   - https://ipapi.co/country
+const Command = `sh -c 'for u in https://ipinfo.io/country https://ifconfig.co/country-iso https://ipapi.co/country; do
+  if command -v curl >/dev/null 2>&1; then
+    r="$(curl -fsS --max-time 6 "$u" 2>/dev/null)"
+  elif command -v wget >/dev/null 2>&1; then
+    r="$(wget -qO- -T 6 "$u" 2>/dev/null)"
+  else
+    exit 0
+  fi
+  r="$(printf "%s" "$r" | tr -d "[:space:]")"
+  case "$r" in
+    [A-Za-z][A-Za-z]) printf "%s" "$r"; exit 0 ;;
+  esac
+done'`
+
+// ParseResponse extracts a recognised ISO 3166-1 alpha-2 country code from the
+// raw stdout of Command. The second return is false (and the code empty) for any
+// output that is not a known two-letter code: an empty/blank response (curl or
+// wget missing, no network, blocked endpoint), garbage, JSON, or an IP address
+// (e.g. an RFC1918 address like "192.168.1.1" — not two letters, so rejected).
+//
+// Requiring the code to be a known country (CountryName non-empty) means stray
+// two-letter tokens such as "XX" or "ZZ" are also rejected, never producing a
+// phantom flag.
+func ParseResponse(raw string) (string, bool) {
+	code := strings.ToUpper(strings.TrimSpace(raw))
+	if len(code) != 2 || !isASCIILetter(code[0]) || !isASCIILetter(code[1]) {
+		return "", false
+	}
+	if CountryName(code) == "" {
+		return "", false
+	}
+	return code, true
+}
+
+// FlagEmoji converts an ISO 3166-1 alpha-2 code into its flag emoji built from
+// the two Regional Indicator Symbols (U+1F1E6..U+1F1FF). It returns "" for any
+// input that is not a recognised two-letter country code, so callers can safely
+// render the result directly (empty = no badge).
+//
+// Platform caveat: some platforms — notably most Windows builds — do not ship
+// flag-emoji glyphs and instead render the two Regional Indicator letters (e.g.
+// "US") as a boxed letter pair. That is an acceptable, automatic degradation:
+// the underlying code points still encode the country, so the badge reads as the
+// ISO code rather than a flag. No image assets are used.
+func FlagEmoji(code string) string {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	if len(code) != 2 || !isASCIILetter(code[0]) || !isASCIILetter(code[1]) {
+		return ""
+	}
+	if CountryName(code) == "" {
+		return ""
+	}
+	const regionalIndicatorBase = 0x1F1E6 // 🇦, the Regional Indicator for 'A'
+	first := rune(regionalIndicatorBase + int(code[0]-'A'))
+	second := rune(regionalIndicatorBase + int(code[1]-'A'))
+	return string([]rune{first, second})
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+// CountryName returns the English country name for an ISO 3166-1 alpha-2 code,
+// or "" when the code is not recognised. It is the single source of truth for
+// "is this a real country code" used by ParseResponse and FlagEmoji.
+func CountryName(code string) string {
+	return countryNames[strings.ToUpper(strings.TrimSpace(code))]
+}

--- a/internal/geoip/geoip_test.go
+++ b/internal/geoip/geoip_test.go
@@ -1,0 +1,113 @@
+package geoip
+
+import "testing"
+
+func TestFlagEmoji(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		want string
+	}{
+		{"upper case US", "US", "\U0001F1FA\U0001F1F8"},
+		{"lower case gb", "gb", "\U0001F1EC\U0001F1E7"},
+		{"mixed case with spaces", "  De ", "\U0001F1E9\U0001F1EA"},
+		{"empty", "", ""},
+		{"single letter", "U", ""},
+		{"three letters", "USA", ""},
+		{"digits", "12", ""},
+		{"unknown two letters", "ZZ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FlagEmoji(tc.code); got != tc.want {
+				t.Fatalf("FlagEmoji(%q) = %q, want %q", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseResponse(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		wantCode string
+		wantOK   bool
+	}{
+		{"valid code", "US", "US", true},
+		{"valid code with newline", "GB\n", "GB", true},
+		{"lower case", "de\n", "DE", true},
+		{"surrounding whitespace", "  fr  \n", "FR", true},
+		{"empty", "", "", false},
+		{"whitespace only", "  \n\t", "", false},
+		{"garbage word", "error", "", false},
+		{"json body", "{\"country\":\"US\"}", "", false},
+		{"private ipv4", "192.168.1.1", "", false},
+		{"loopback ipv4", "127.0.0.1", "", false},
+		{"reserved ipv4", "10.0.0.5", "", false},
+		{"unknown code", "ZZ", "", false},
+		{"three letters", "USA", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCode, gotOK := ParseResponse(tc.raw)
+			if gotCode != tc.wantCode || gotOK != tc.wantOK {
+				t.Fatalf("ParseResponse(%q) = (%q, %v), want (%q, %v)", tc.raw, gotCode, gotOK, tc.wantCode, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseResponseThenFlag(t *testing.T) {
+	// A successful parse must always yield a non-empty flag, and a failed parse
+	// must always yield an empty flag (no phantom badge).
+	if code, ok := ParseResponse("US"); !ok || FlagEmoji(code) == "" {
+		t.Fatalf("valid response should produce a flag, got code=%q ok=%v flag=%q", code, ok, FlagEmoji(code))
+	}
+	if code, ok := ParseResponse("192.168.0.1"); ok || FlagEmoji(code) != "" {
+		t.Fatalf("private IP should produce no flag, got code=%q ok=%v flag=%q", code, ok, FlagEmoji(code))
+	}
+}
+
+func TestCountryName(t *testing.T) {
+	if got := CountryName("US"); got != "United States" {
+		t.Fatalf("CountryName(US) = %q, want United States", got)
+	}
+	if got := CountryName("gb"); got != "United Kingdom" {
+		t.Fatalf("CountryName(gb) = %q, want United Kingdom", got)
+	}
+	if got := CountryName("ZZ"); got != "" {
+		t.Fatalf("CountryName(ZZ) = %q, want empty", got)
+	}
+}
+
+func TestCountryDataWellFormed(t *testing.T) {
+	// Every recognised code must be exactly two upper-case ASCII letters and must
+	// round-trip through FlagEmoji to a non-empty badge.
+	if len(countryNames) < 200 {
+		t.Fatalf("country table looks too small: %d entries", len(countryNames))
+	}
+	for code, name := range countryNames {
+		if len(code) != 2 || !isASCIILetter(code[0]) || !isASCIILetter(code[1]) {
+			t.Fatalf("malformed country code %q", code)
+		}
+		if code != toUpper(code) {
+			t.Fatalf("country code %q is not upper-case", code)
+		}
+		if name == "" {
+			t.Fatalf("country code %q has an empty name", code)
+		}
+		if FlagEmoji(code) == "" {
+			t.Fatalf("country code %q produced no flag", code)
+		}
+	}
+}
+
+func toUpper(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -46,6 +46,12 @@ func NewRouter(cfg config.Config, database *db.Runtime, sshService *sshclient.Se
 		LiveMetrics:     liveMetrics,
 		Renderer:        renderer,
 	}
+	// Assign the scheduler as the country resolver only when it is actually
+	// present, so the interface field stays a true nil (not a typed nil) when the
+	// scheduler is unavailable and handlers can rely on a plain nil check.
+	if backgroundScheduler != nil {
+		deps.CountryResolver = backgroundScheduler
+	}
 
 	health := handlers.NewHealthHandler(cfg, database)
 

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -22,6 +22,17 @@ type Dependencies struct {
 	TerminalTickets *terminalticket.Store
 	LiveMetrics     *livemetrics.Hub
 	Renderer        *view.Renderer
+	// CountryResolver triggers background country detection for a server (e.g.
+	// after create/update). It is satisfied by the scheduler runtime and may be
+	// nil when the scheduler is unavailable, so callers must nil-check it.
+	CountryResolver CountryResolver
+}
+
+// CountryResolver kicks off best-effort, non-blocking country detection for a
+// single server over its SSH connection. Implementations must never block the
+// caller and must tolerate a missing/unreachable server.
+type CountryResolver interface {
+	ResolveCountryAsync(serverID int64)
 }
 
 type Module interface {

--- a/internal/module/servers/crud_handlers.go
+++ b/internal/module/servers/crud_handlers.go
@@ -65,6 +65,13 @@ func (h CreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Detect the new server's country in the background. This must not block or
+	// fail the create — the flag is filled in asynchronously (and by later
+	// scheduler sweeps) over the server's own SSH connection.
+	if h.deps.CountryResolver != nil {
+		h.deps.CountryResolver.ResolveCountryAsync(created.ID)
+	}
+
 	http.Redirect(w, r, "/servers?flash=created&id="+formatID(created.ID), http.StatusSeeOther)
 }
 
@@ -153,6 +160,12 @@ func (h UpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		renderRepositoryError(w, h.deps, err, "Could not update server", "The server record could not be updated.")
 		return
+	}
+
+	// Host or credentials may have changed, so re-detect the country in the
+	// background. Non-blocking and best-effort, exactly like the create path.
+	if h.deps.CountryResolver != nil {
+		h.deps.CountryResolver.ResolveCountryAsync(updated.ID)
 	}
 
 	http.Redirect(w, r, "/servers?flash=updated&id="+formatID(updated.ID), http.StatusSeeOther)

--- a/internal/module/servers/pages.go
+++ b/internal/module/servers/pages.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Ho3einK84/Nodexia/internal/geoip"
 	"github.com/Ho3einK84/Nodexia/internal/http/middleware"
 	"github.com/Ho3einK84/Nodexia/internal/module"
 	"github.com/Ho3einK84/Nodexia/internal/view"
@@ -49,6 +50,9 @@ func renderListPage(w http.ResponseWriter, r *http.Request, deps module.Dependen
 			CredentialRef:      server.CredentialRef,
 			CreatedAt:          formatTimestamp(server.CreatedAt),
 			UpdatedAt:          formatTimestamp(server.UpdatedAt),
+			FlagEmoji:          geoip.FlagEmoji(server.CountryCode),
+			CountryCode:        server.CountryCode,
+			CountryName:        server.CountryName,
 		}
 		if ts, ok := lastSeen[server.ID]; ok {
 			age := time.Since(ts)
@@ -114,6 +118,8 @@ func serverMatchesQuery(server Server, query string) bool {
 		server.Note,
 		server.AuthMode,
 		server.CredentialStrategy,
+		server.CountryCode,
+		server.CountryName,
 		strconv.Itoa(server.Port),
 	}
 	for _, field := range haystacks {

--- a/internal/module/servers/repository.go
+++ b/internal/module/servers/repository.go
@@ -16,8 +16,16 @@ type Server struct {
 	Tags               []string
 	CredentialStrategy string
 	CredentialRef      string
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
+	// CountryCode is the detected ISO 3166-1 alpha-2 country code for the node's
+	// public-IP egress (resolved over SSH, see internal/geoip), or "" when it is
+	// unknown / undetectable. CountryName is the matching human-readable name.
+	// CountryCheckedAt is the last resolution attempt (success or empty); a zero
+	// value means detection has never run for this server.
+	CountryCode      string
+	CountryName      string
+	CountryCheckedAt time.Time
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 type Repository interface {
@@ -26,4 +34,10 @@ type Repository interface {
 	List(ctx context.Context) ([]Server, error)
 	Update(ctx context.Context, server Server) (Server, error)
 	Delete(ctx context.Context, id int64) error
+	// UpdateCountry persists a freshly detected country for one server and stamps
+	// the check time. It is intentionally separate from Update so that country
+	// detection (driven by the scheduler / async resolver) never collides with
+	// form-driven edits and never touches credentials or other fields. An empty
+	// code/name records "checked, nothing detected" so callers can back off.
+	UpdateCountry(ctx context.Context, id int64, code, name string) error
 }

--- a/internal/module/servers/sql_repository.go
+++ b/internal/module/servers/sql_repository.go
@@ -69,7 +69,7 @@ func (r SQLRepository) Create(ctx context.Context, server Server) (Server, error
 func (r SQLRepository) GetByID(ctx context.Context, id int64) (Server, error) {
 	row := r.conn.QueryRowContext(
 		ctx,
-		`SELECT id, name, host, port, auth_mode, username, note, credential_strategy, credential_ref, created_at, updated_at
+		`SELECT id, name, host, port, auth_mode, username, note, credential_strategy, credential_ref, country_code, country_name, country_checked_at, created_at, updated_at
 		 FROM servers
 		 WHERE id = ?
 		 LIMIT 1`,
@@ -97,7 +97,7 @@ func (r SQLRepository) GetByID(ctx context.Context, id int64) (Server, error) {
 func (r SQLRepository) List(ctx context.Context) ([]Server, error) {
 	rows, err := r.conn.QueryContext(
 		ctx,
-		`SELECT id, name, host, port, auth_mode, username, note, credential_strategy, credential_ref, created_at, updated_at
+		`SELECT id, name, host, port, auth_mode, username, note, credential_strategy, credential_ref, country_code, country_name, country_checked_at, created_at, updated_at
 		 FROM servers
 		 ORDER BY id DESC`,
 	)
@@ -184,6 +184,33 @@ func (r SQLRepository) Update(ctx context.Context, server Server) (Server, error
 	return r.GetByID(ctx, server.ID)
 }
 
+// UpdateCountry writes the detected country (or an empty result) for one server
+// and stamps country_checked_at. It deliberately updates only the country
+// columns — not updated_at or any credential/identity field — so detection never
+// interferes with the audit trail of user edits. A missing server is a no-op
+// (returns nil): the row may have been deleted between detection and write, and
+// that is not an error worth surfacing to a background job.
+func (r SQLRepository) UpdateCountry(ctx context.Context, id int64, code, name string) error {
+	code = strings.TrimSpace(code)
+	name = strings.TrimSpace(name)
+	now := time.Now().UTC()
+
+	if _, err := r.conn.ExecContext(
+		ctx,
+		`UPDATE servers
+		 SET country_code = ?, country_name = ?, country_checked_at = ?
+		 WHERE id = ?`,
+		code,
+		name,
+		now,
+		id,
+	); err != nil {
+		return fmt.Errorf("servers: update country %d: %w", id, err)
+	}
+
+	return nil
+}
+
 func (r SQLRepository) Delete(ctx context.Context, id int64) error {
 	tx, err := r.conn.BeginTx(ctx, nil)
 	if err != nil {
@@ -239,6 +266,7 @@ func scanServer(scanner rowScanner) (Server, error) {
 	var server Server
 	var createdAtRaw any
 	var updatedAtRaw any
+	var countryCheckedAtRaw any
 
 	if err := scanner.Scan(
 		&server.ID,
@@ -250,6 +278,9 @@ func scanServer(scanner rowScanner) (Server, error) {
 		&server.Note,
 		&server.CredentialStrategy,
 		&server.CredentialRef,
+		&server.CountryCode,
+		&server.CountryName,
+		&countryCheckedAtRaw,
 		&createdAtRaw,
 		&updatedAtRaw,
 	); err != nil {
@@ -266,6 +297,13 @@ func scanServer(scanner rowScanner) (Server, error) {
 		return Server{}, fmt.Errorf("parse updated_at: %w", err)
 	}
 
+	// country_checked_at is nullable; a NULL maps to a zero time (never checked).
+	countryCheckedAt, err := parseDatabaseTime(countryCheckedAtRaw)
+	if err != nil {
+		return Server{}, fmt.Errorf("parse country_checked_at: %w", err)
+	}
+
+	server.CountryCheckedAt = countryCheckedAt
 	server.CreatedAt = createdAt
 	server.UpdatedAt = updatedAt
 	return server, nil

--- a/internal/module/servers/sql_repository_test.go
+++ b/internal/module/servers/sql_repository_test.go
@@ -54,3 +54,66 @@ func TestSQLRepositoryCRUD(t *testing.T) {
 		t.Fatal("expected not found after delete")
 	}
 }
+
+func TestSQLRepositoryUpdateCountry(t *testing.T) {
+	runtime := testutil.OpenTestDB(t)
+	repo := servers.NewSQLRepository(runtime.SQL)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, servers.Server{
+		Name:               "geo-1",
+		Host:               "203.0.113.10",
+		Port:               22,
+		AuthMode:           servers.AuthModePassword,
+		Username:           "ubuntu",
+		CredentialStrategy: servers.CredentialStrategyStored,
+		CredentialRef:      "secret",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// A fresh server has no detected country yet.
+	if created.CountryCode != "" || created.CountryName != "" || !created.CountryCheckedAt.IsZero() {
+		t.Fatalf("new server should have empty country, got %#v", created)
+	}
+
+	if err := repo.UpdateCountry(ctx, created.ID, "US", "United States"); err != nil {
+		t.Fatalf("UpdateCountry() error = %v", err)
+	}
+
+	fetched, err := repo.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if fetched.CountryCode != "US" || fetched.CountryName != "United States" {
+		t.Fatalf("country not persisted, got %#v", fetched)
+	}
+	if fetched.CountryCheckedAt.IsZero() {
+		t.Fatal("country_checked_at should be stamped after UpdateCountry")
+	}
+	// UpdateCountry must not disturb identity/credential fields.
+	if fetched.Host != "203.0.113.10" || fetched.CredentialRef != "secret" {
+		t.Fatalf("UpdateCountry altered unrelated fields: %#v", fetched)
+	}
+
+	// An empty result records "checked, nothing detected" without erroring.
+	if err := repo.UpdateCountry(ctx, created.ID, "", ""); err != nil {
+		t.Fatalf("UpdateCountry(empty) error = %v", err)
+	}
+	cleared, err := repo.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if cleared.CountryCode != "" || cleared.CountryName != "" {
+		t.Fatalf("empty UpdateCountry should clear country, got %#v", cleared)
+	}
+	if cleared.CountryCheckedAt.IsZero() {
+		t.Fatal("country_checked_at should still be stamped after empty UpdateCountry")
+	}
+
+	// A missing server is a no-op, not an error.
+	if err := repo.UpdateCountry(ctx, 999999, "GB", "United Kingdom"); err != nil {
+		t.Fatalf("UpdateCountry(missing) error = %v", err)
+	}
+}

--- a/internal/scheduler/country.go
+++ b/internal/scheduler/country.go
@@ -1,0 +1,174 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Ho3einK84/Nodexia/internal/db"
+	"github.com/Ho3einK84/Nodexia/internal/geoip"
+	"github.com/Ho3einK84/Nodexia/internal/module/servers"
+)
+
+const (
+	// countryInitialDelay is how long after Start the first country sweep runs.
+	// Short enough that a fresh install populates flags quickly, long enough to
+	// stay out of the way of the startup burst.
+	countryInitialDelay = 30 * time.Second
+	// countrySweepInterval is how often the country sweep wakes up. Each wake only
+	// resolves servers that are missing or stale, so this is cheap; it mainly
+	// bounds how soon a newly added server is picked up if the create-time async
+	// kick did not run (e.g. scheduler started after the server already existed).
+	countrySweepInterval = time.Hour
+	// countryRefreshInterval is the minimum age before an already-checked server is
+	// re-resolved. Kept generous (daily) because the free geo services rate-limit
+	// and a node's country rarely changes.
+	countryRefreshInterval = 24 * time.Hour
+	// countryResolveTimeout bounds a single resolution (connect + the multi-endpoint
+	// probe). The remote probe tries up to three endpoints at ~6s each.
+	countryResolveTimeout = 45 * time.Second
+	// countryCommandTimeout bounds just the remote probe command. It must exceed
+	// the worst-case sum of the per-endpoint curl/wget timeouts in geoip.Command.
+	countryCommandTimeout = 30 * time.Second
+)
+
+// ResolveCountryAsync detects and stores one server's country in the background.
+// It is the hook the server create/update handlers call so a flag appears
+// without waiting on (or failing because of) a slow SSH round-trip. It never
+// blocks the caller and never returns an error: detection failures are logged at
+// debug and simply leave the country to be filled in by a later sweep.
+//
+// A nil receiver (scheduler unavailable) is a safe no-op.
+func (r *Runtime) ResolveCountryAsync(serverID int64) {
+	if r == nil {
+		return
+	}
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+
+		ctx, cancel := context.WithTimeout(context.Background(), countryResolveTimeout)
+		defer cancel()
+
+		server, err := r.serverRepo.GetByID(ctx, serverID)
+		if err != nil {
+			return
+		}
+		if !r.evaluateEligibility(server).Allowed {
+			// No usable credentials — nothing to connect with, so skip silently.
+			return
+		}
+		if err := r.resolveCountry(ctx, server); err != nil {
+			slog.Debug("country detection failed",
+				slog.Int64("server_id", serverID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+}
+
+// countryLoop periodically refreshes server countries. It runs an initial sweep
+// shortly after startup and then on a generous ticker; each sweep only touches
+// servers that are missing a country or whose last check is stale.
+func (r *Runtime) countryLoop(ctx context.Context) {
+	defer r.wg.Done()
+
+	initial := time.NewTimer(countryInitialDelay)
+	defer initial.Stop()
+	ticker := time.NewTicker(countrySweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-initial.C:
+			r.refreshCountries(ctx)
+		case <-ticker.C:
+			r.refreshCountries(ctx)
+		}
+	}
+}
+
+// refreshCountries resolves the country for every eligible server that has never
+// been checked or whose last check has aged past countryRefreshInterval. Servers
+// are processed one at a time so the sweep never opens a burst of SSH
+// connections, and a per-server timeout keeps one slow node from stalling the
+// rest.
+func (r *Runtime) refreshCountries(ctx context.Context) {
+	serversList, err := r.serverRepo.List(ctx)
+	if err != nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, server := range serversList {
+		if ctx.Err() != nil {
+			return
+		}
+		if !r.countryDue(server, now) {
+			continue
+		}
+		if !r.evaluateEligibility(server).Allowed {
+			continue
+		}
+
+		resolveCtx, cancel := context.WithTimeout(ctx, countryResolveTimeout)
+		if err := r.resolveCountry(resolveCtx, server); err != nil {
+			slog.Debug("country detection failed",
+				slog.Int64("server_id", server.ID),
+				slog.String("error", err.Error()),
+			)
+		}
+		cancel()
+	}
+}
+
+// countryDue reports whether a server should be (re)resolved now. It keys off the
+// check timestamp rather than whether a code is present, so a server that
+// genuinely has no detectable country (empty result stored with a fresh
+// timestamp) backs off until the refresh interval instead of being retried every
+// sweep.
+func (r *Runtime) countryDue(server servers.Server, now time.Time) bool {
+	if server.CountryCheckedAt.IsZero() {
+		return true
+	}
+	return now.Sub(server.CountryCheckedAt) >= countryRefreshInterval
+}
+
+// resolveCountry runs the remote geo probe over SSH and persists the result.
+//
+// Failure handling is deliberate:
+//   - A connection/SSH error returns the error WITHOUT persisting, so the check
+//     timestamp stays put and the server is retried on the next sweep.
+//   - A successful probe that yields no recognised code (no public egress,
+//     blocked endpoints, garbage, or a private/reserved address — see
+//     geoip.ParseResponse) stores an empty country WITH a fresh timestamp, which
+//     records "checked, nothing to show" and backs detection off until the next
+//     refresh interval instead of hammering the rate-limited services.
+func (r *Runtime) resolveCountry(ctx context.Context, server servers.Server) error {
+	req, _, err := r.connectionRequestFor(server)
+	if err != nil {
+		return err
+	}
+	req.Command = geoip.Command
+	req.CommandTimeout = countryCommandTimeout
+
+	result, err := r.ssh.RunCommand(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	code, ok := geoip.ParseResponse(result.Stdout)
+	name := ""
+	if ok {
+		name = geoip.CountryName(code)
+	} else {
+		code = ""
+	}
+
+	return db.RetryOnBusy(ctx, func() error {
+		return r.serverRepo.UpdateCountry(ctx, server.ID, code, name)
+	})
+}

--- a/internal/scheduler/runtime.go
+++ b/internal/scheduler/runtime.go
@@ -201,9 +201,10 @@ func (r *Runtime) Start() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
-	r.wg.Add(2)
+	r.wg.Add(3)
 	go r.loop(ctx)
 	go r.analyticsLoop(ctx)
+	go r.countryLoop(ctx)
 }
 
 // analyticsLoop runs hourly metric rollups and daily cleanup on independent
@@ -489,7 +490,13 @@ func (r *Runtime) launchJob(parent context.Context, server servers.Server, jobTy
 	}()
 }
 
-func (r *Runtime) executeJob(ctx context.Context, server servers.Server, jobType JobType) (string, error) {
+// connectionRequestFor resolves a server's SSH credentials (honouring its
+// credential strategy) and builds a CommandRequest ready for a command to be
+// attached. It is shared by the monitoring/nodes jobs and the country resolver
+// so credential handling stays in exactly one place. It also returns the
+// resolved credential so callers that need its extra fields (e.g. the traffic
+// interface) can use them.
+func (r *Runtime) connectionRequestFor(server servers.Server) (sshclient.CommandRequest, resolvedCredential, error) {
 	var credentials resolvedCredential
 	authMode := server.AuthMode
 
@@ -511,7 +518,7 @@ func (r *Runtime) executeJob(ctx context.Context, server servers.Server, jobType
 		var err error
 		credentials, err = resolveCredential(server.AuthMode, server.CredentialRef)
 		if err != nil {
-			return "", err
+			return sshclient.CommandRequest{}, resolvedCredential{}, err
 		}
 	}
 
@@ -527,6 +534,14 @@ func (r *Runtime) executeJob(ctx context.Context, server servers.Server, jobType
 			ConnectTimeout: r.cfg.ConnectTimeout,
 		},
 		CommandTimeout: r.cfg.CommandTimeout,
+	}
+	return req, credentials, nil
+}
+
+func (r *Runtime) executeJob(ctx context.Context, server servers.Server, jobType JobType) (string, error) {
+	req, credentials, err := r.connectionRequestFor(server)
+	if err != nil {
+		return "", err
 	}
 
 	switch jobType {

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -150,6 +150,12 @@ type ServerSummary struct {
 	// older snapshot data; both are empty when no snapshots exist.
 	IsOnline   bool
 	LastSeenAt string
+	// FlagEmoji is the detected country's flag (regional-indicator emoji), or ""
+	// when the country is unknown/undetected. CountryName is the human-readable
+	// name shown on hover; CountryCode is the ISO 3166-1 alpha-2 code.
+	FlagEmoji   string
+	CountryCode string
+	CountryName string
 }
 
 type ServerFormView struct {

--- a/schema.sql
+++ b/schema.sql
@@ -279,3 +279,16 @@ CREATE TABLE IF NOT EXISTS metric_rollups_daily (
 
 CREATE INDEX IF NOT EXISTS idx_metric_rollups_daily_server_period
   ON metric_rollups_daily (server_id, period_start);
+
+-- ── Geo / country detection ───────────────────────────────────────────────────
+-- Each server's detected public-IP country is cached on the row so it never has
+-- to be looked up on a page render. Detection runs over the established SSH
+-- connection to the node (see internal/geoip), so the code reflects the node's
+-- own egress IP rather than the panel's network. Appended as standalone
+-- statements so existing databases pick them up as new bootstrap migrations.
+-- country_checked_at records the last resolution attempt (success OR empty) so
+-- the scheduler can back off and refresh on a generous cadence instead of
+-- hammering the rate-limited geo services.
+ALTER TABLE servers ADD COLUMN country_code TEXT NOT NULL DEFAULT '';
+ALTER TABLE servers ADD COLUMN country_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE servers ADD COLUMN country_checked_at DATETIME;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -393,6 +393,17 @@ body {
   word-break: break-all;
 }
 
+/* Country flag badge next to the server name. The glyph is a regional-indicator
+   emoji; on platforms without flag-emoji support (e.g. most Windows builds) the
+   browser renders the two letters of the ISO code instead, which is an
+   acceptable text fallback. */
+.server-card__flag {
+  font-size: 1.05rem;
+  line-height: 1;
+  vertical-align: middle;
+  cursor: default;
+}
+
 .server-card__badges {
   display: flex;
   gap: 6px;

--- a/web/templates/servers.gohtml
+++ b/web/templates/servers.gohtml
@@ -77,7 +77,7 @@
               aria-label="Select {{ .Name }}">
           </div>
           <div class="server-card__identity">
-            <h4 class="server-card__name"><i data-lucide="server" class="icon-in-button"></i> {{ .Name }}</h4>
+            <h4 class="server-card__name"><i data-lucide="server" class="icon-in-button"></i> {{ .Name }}{{ if .FlagEmoji }} <span class="server-card__flag" title="{{ .CountryName }}" aria-label="{{ .CountryName }}">{{ .FlagEmoji }}</span>{{ end }}</h4>
             <span class="server-card__host">{{ .Username }}@{{ .Host }}:{{ .Port }}</span>
             {{ if .IsOnline }}
             <span class="server-card__status server-status--online"><span class="status-pulse"></span>Online</span>


### PR DESCRIPTION
Detect each server's country over its established SSH connection (not the panel's network) and cache the ISO code + name on the server row, then show the flag emoji next to the server name.

- internal/geoip: keyless remote probe (curl/wget, ipinfo.io + fallbacks), response parsing, and ISO->flag-emoji conversion. Pure and unit-tested; private IPs / garbage / no-network all yield no flag.
- servers: country_code/country_name/country_checked_at columns (appended as bootstrap migrations, sqlite+mysql safe) and a dedicated UpdateCountry that never touches credentials or updated_at.
- scheduler: async resolve on create/update plus a generous daily refresh sweep; SSH errors retry next sweep, empty results back off.
- UI: flag badge with country-name title on the servers list; country added to the search filter. Windows degrades to the ISO letters automatically.