### PR TITLE
feat(analytics,alerts): show server country flag

### DIFF
--- a/internal/module/alerts/event_flag_test.go
+++ b/internal/module/alerts/event_flag_test.go
@@ -1,0 +1,44 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBuildEventRowsFlag verifies that event rows carry the flag emoji for a
+// server with a detected country and render nothing for one without — matching
+// the graceful degradation of the servers list.
+func TestBuildEventRowsFlag(t *testing.T) {
+	refs := []serverRef{
+		{ID: 1, Name: "tokyo-1", CountryCode: "JP"},
+		{ID: 2, Name: "private-1", CountryCode: ""},
+	}
+	names := serverNameMap(refs)
+	countries := serverCountryMap(refs)
+
+	events := []Event{
+		{ID: 10, ServerID: 1, Metric: "cpu", Severity: "warning", State: "firing", FiredAt: time.Now()},
+		{ID: 11, ServerID: 2, Metric: "ram", Severity: "warning", State: "firing", FiredAt: time.Now()},
+	}
+
+	rows := buildEventRows(events, names, countries)
+	if len(rows) != 2 {
+		t.Fatalf("buildEventRows() len = %d, want 2", len(rows))
+	}
+
+	// Server with a known country: flag and hover title present.
+	if rows[0].FlagEmoji != "🇯🇵" {
+		t.Errorf("row[0].FlagEmoji = %q, want Japan flag", rows[0].FlagEmoji)
+	}
+	if rows[0].CountryName != "Japan" {
+		t.Errorf("row[0].CountryName = %q, want %q", rows[0].CountryName, "Japan")
+	}
+
+	// Server without a detected country: no flag, no title.
+	if rows[1].FlagEmoji != "" {
+		t.Errorf("row[1].FlagEmoji = %q, want empty", rows[1].FlagEmoji)
+	}
+	if rows[1].CountryName != "" {
+		t.Errorf("row[1].CountryName = %q, want empty", rows[1].CountryName)
+	}
+}

--- a/internal/module/alerts/handlers.go
+++ b/internal/module/alerts/handlers.go
@@ -486,7 +486,7 @@ func (h Handlers) loadServerRefs(ctx context.Context) ([]serverRef, error) {
 	}
 	refs := make([]serverRef, 0, len(list))
 	for _, server := range list {
-		refs = append(refs, serverRef{ID: server.ID, Name: server.Name})
+		refs = append(refs, serverRef{ID: server.ID, Name: server.Name, CountryCode: server.CountryCode})
 	}
 	return refs, nil
 }

--- a/internal/module/alerts/view.go
+++ b/internal/module/alerts/view.go
@@ -5,15 +5,18 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Ho3einK84/Nodexia/internal/geoip"
 	"github.com/Ho3einK84/Nodexia/internal/view"
 )
 
 // serverRef is the minimal server identity the alerts views need. The handler
 // builds these from the servers repository so this module stays decoupled from
-// the full server record.
+// the full server record. CountryCode is the detected ISO 3166-1 alpha-2 code
+// (or "" when unknown) used to render a flag badge next to the server.
 type serverRef struct {
-	ID   int64
-	Name string
+	ID          int64
+	Name        string
+	CountryCode string
 }
 
 func serverNameMap(refs []serverRef) map[int64]string {
@@ -22,6 +25,16 @@ func serverNameMap(refs []serverRef) map[int64]string {
 		names[ref.ID] = ref.Name
 	}
 	return names
+}
+
+// serverCountryMap indexes each server's detected country code by id so event
+// rows can render a flag without an extra lookup per event.
+func serverCountryMap(refs []serverRef) map[int64]string {
+	codes := make(map[int64]string, len(refs))
+	for _, ref := range refs {
+		codes[ref.ID] = ref.CountryCode
+	}
+	return codes
 }
 
 func channelNameMap(channels []Channel) map[int64]string {
@@ -45,6 +58,7 @@ func buildOverview(
 	now time.Time,
 ) view.AlertsOverviewView {
 	names := serverNameMap(servers)
+	countries := serverCountryMap(servers)
 	channelNames := channelNameMap(channels)
 
 	notice := ""
@@ -56,7 +70,7 @@ func buildOverview(
 		Rules:           buildRuleRows(rules, names, channelNames, streaks),
 		Channels:        buildChannelRows(channels),
 		Silences:        buildSilenceRows(silences, names, now),
-		Events:          buildEventRows(events, names),
+		Events:          buildEventRows(events, names, countries),
 		SilenceForm:     buildSilenceFormView(SilenceFormInput{}, ValidationErrors{}, servers),
 		HasServers:      len(servers) > 0,
 		NewRuleURL:      "/alerts/rules/new",
@@ -66,7 +80,7 @@ func buildOverview(
 	}
 }
 
-func buildEventRows(events []Event, serverNames map[int64]string) []view.AlertEventView {
+func buildEventRows(events []Event, serverNames, serverCountries map[int64]string) []view.AlertEventView {
 	rows := make([]view.AlertEventView, 0, len(events))
 	for _, event := range events {
 		serverID := event.ServerID
@@ -75,8 +89,11 @@ func buildEventRows(events []Event, serverNames map[int64]string) []view.AlertEv
 			resolvedAt = formatTimestamp(*event.ResolvedAt)
 		}
 
+		code := serverCountries[serverID]
 		rows = append(rows, view.AlertEventView{
 			ServerLabel: serverLabel(serverNames, &serverID),
+			FlagEmoji:   geoip.FlagEmoji(code),
+			CountryName: geoip.CountryName(code),
 			MetricLabel: MetricLabel(event.Metric),
 			Value:       FormatThresholdWithUnit(event.Metric, event.ObservedValue),
 			Threshold:   FormatThresholdWithUnit(event.Metric, event.Threshold),

--- a/internal/module/analytics/handlers.go
+++ b/internal/module/analytics/handlers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Ho3einK84/Nodexia/internal/geoip"
 	"github.com/Ho3einK84/Nodexia/internal/http/httperrors"
 	"github.com/Ho3einK84/Nodexia/internal/http/middleware"
 	"github.com/Ho3einK84/Nodexia/internal/module"
@@ -156,11 +157,13 @@ func (h GlobalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metricViews := make([]view.TopServerMetricView, 0, len(topMetrics))
 	for _, s := range topMetrics {
 		metricViews = append(metricViews, view.TopServerMetricView{
-			ServerID:   s.ServerID,
-			ServerName: s.ServerName,
-			CPU:        fmt.Sprintf("%.1f%%", s.AvgCPU),
-			RAM:        fmt.Sprintf("%.1f%%", s.AvgRAM),
-			Disk:       fmt.Sprintf("%.1f%%", s.AvgDisk),
+			ServerID:    s.ServerID,
+			ServerName:  s.ServerName,
+			FlagEmoji:   geoip.FlagEmoji(s.CountryCode),
+			CountryName: geoip.CountryName(s.CountryCode),
+			CPU:         fmt.Sprintf("%.1f%%", s.AvgCPU),
+			RAM:         fmt.Sprintf("%.1f%%", s.AvgRAM),
+			Disk:        fmt.Sprintf("%.1f%%", s.AvgDisk),
 		})
 	}
 
@@ -175,12 +178,14 @@ func (h GlobalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	trafficViews := make([]view.TopServerTrafficView, 0, len(topTraffic))
 	for _, s := range topTraffic {
 		trafficViews = append(trafficViews, view.TopServerTrafficView{
-			ServerID:   s.ServerID,
-			ServerName: s.ServerName,
-			Download:   formatBytes(s.MonthRX),
-			Upload:     formatBytes(s.MonthTX),
-			MonthBytes: formatBytes(s.MonthBytes),
-			MonthLabel: s.MonthLabel,
+			ServerID:    s.ServerID,
+			ServerName:  s.ServerName,
+			FlagEmoji:   geoip.FlagEmoji(s.CountryCode),
+			CountryName: geoip.CountryName(s.CountryCode),
+			Download:    formatBytes(s.MonthRX),
+			Upload:      formatBytes(s.MonthTX),
+			MonthBytes:  formatBytes(s.MonthBytes),
+			MonthLabel:  s.MonthLabel,
 		})
 	}
 

--- a/internal/module/analytics/repository.go
+++ b/internal/module/analytics/repository.go
@@ -70,10 +70,14 @@ type TrafficMonth struct {
 type ServerMetricSummary struct {
 	ServerID   int64
 	ServerName string
-	AvgCPU     float64
-	AvgRAM     float64
-	AvgDisk    float64
-	AvgSwap    float64
+	// CountryCode is the server's detected ISO 3166-1 alpha-2 code (or "" when
+	// unknown), folded into the metric query so the overview can show a flag
+	// without an extra per-row lookup.
+	CountryCode string
+	AvgCPU      float64
+	AvgRAM      float64
+	AvgDisk     float64
+	AvgSwap     float64
 }
 
 // ServerTrafficSummary holds the current-month traffic totals for one server,
@@ -81,10 +85,14 @@ type ServerMetricSummary struct {
 type ServerTrafficSummary struct {
 	ServerID   int64
 	ServerName string
-	MonthRX    int64
-	MonthTX    int64
-	MonthBytes int64
-	MonthLabel string
+	// CountryCode is the server's detected ISO 3166-1 alpha-2 code (or "" when
+	// unknown), folded into the traffic query so the overview can show a flag
+	// without an extra per-row lookup.
+	CountryCode string
+	MonthRX     int64
+	MonthTX     int64
+	MonthBytes  int64
+	MonthLabel  string
 }
 
 // Repository abstracts all analytics data access.

--- a/internal/module/analytics/sql_repository.go
+++ b/internal/module/analytics/sql_repository.go
@@ -274,7 +274,7 @@ func (r SQLRepository) ListServerMetricSummaries(ctx context.Context, limit int)
 		limit = 10
 	}
 	rows, err := r.conn.QueryContext(ctx,
-		`SELECT ss.server_id, s.name,
+		`SELECT ss.server_id, s.name, s.country_code,
 		        ss.cpu_usage, ss.ram_usage, ss.disk_usage, ss.swap_usage
 		 FROM system_snapshots ss
 		 JOIN servers s ON s.id = ss.server_id
@@ -294,7 +294,7 @@ func (r SQLRepository) ListServerMetricSummaries(ctx context.Context, limit int)
 	var summaries []ServerMetricSummary
 	for rows.Next() {
 		var s ServerMetricSummary
-		if err := rows.Scan(&s.ServerID, &s.ServerName, &s.AvgCPU, &s.AvgRAM, &s.AvgDisk, &s.AvgSwap); err != nil {
+		if err := rows.Scan(&s.ServerID, &s.ServerName, &s.CountryCode, &s.AvgCPU, &s.AvgRAM, &s.AvgDisk, &s.AvgSwap); err != nil {
 			return nil, fmt.Errorf("analytics: scan server metric summary: %w", err)
 		}
 		summaries = append(summaries, s)
@@ -309,7 +309,7 @@ func (r SQLRepository) ListServerMetricSummaries(ctx context.Context, limit int)
 // arbitrary N rows before sorting, so the real top consumers could be dropped.)
 func (r SQLRepository) ListServerTrafficSummaries(ctx context.Context, limit int) ([]ServerTrafficSummary, error) {
 	rows, err := r.conn.QueryContext(ctx,
-		`SELECT vs.server_id, s.name, vs.monthly_rows_json
+		`SELECT vs.server_id, s.name, s.country_code, vs.monthly_rows_json
 		 FROM vnstat_snapshots vs
 		 JOIN servers s ON s.id = vs.server_id
 		 JOIN (
@@ -335,8 +335,8 @@ func (r SQLRepository) ListServerTrafficSummaries(ctx context.Context, limit int
 	var summaries []ServerTrafficSummary
 	for rows.Next() {
 		var serverID int64
-		var serverName, monthlyJSON string
-		if err := rows.Scan(&serverID, &serverName, &monthlyJSON); err != nil {
+		var serverName, countryCode, monthlyJSON string
+		if err := rows.Scan(&serverID, &serverName, &countryCode, &monthlyJSON); err != nil {
 			return nil, fmt.Errorf("analytics: scan server traffic summary: %w", err)
 		}
 		var monthlyRows []rawRow
@@ -354,12 +354,13 @@ func (r SQLRepository) ListServerTrafficSummaries(ctx context.Context, limit int
 			}
 		}
 		summaries = append(summaries, ServerTrafficSummary{
-			ServerID:   serverID,
-			ServerName: serverName,
-			MonthRX:    rx,
-			MonthTX:    tx,
-			MonthBytes: monthBytes,
-			MonthLabel: currentMonth,
+			ServerID:    serverID,
+			ServerName:  serverName,
+			CountryCode: countryCode,
+			MonthRX:     rx,
+			MonthTX:     tx,
+			MonthBytes:  monthBytes,
+			MonthLabel:  currentMonth,
 		})
 	}
 	return summaries, rows.Err()

--- a/internal/module/analytics/sql_repository_country_test.go
+++ b/internal/module/analytics/sql_repository_country_test.go
@@ -1,0 +1,105 @@
+package analytics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Ho3einK84/Nodexia/internal/module/analytics"
+	"github.com/Ho3einK84/Nodexia/internal/module/servers"
+	"github.com/Ho3einK84/Nodexia/internal/testutil"
+)
+
+// TestServerSummariesCarryCountryCode verifies that the overview queries fold
+// each server's detected country code into the row, and leave it empty for a
+// server without a detected country — so the template degrades gracefully.
+func TestServerSummariesCarryCountryCode(t *testing.T) {
+	runtime := testutil.OpenTestDB(t)
+	ctx := context.Background()
+
+	serverRepo := servers.NewSQLRepository(runtime.SQL)
+	withCountry, err := serverRepo.Create(ctx, servers.Server{
+		Name:               "tokyo-1",
+		Host:               "203.0.113.10",
+		Port:               22,
+		AuthMode:           servers.AuthModePassword,
+		Username:           "ubuntu",
+		CredentialStrategy: servers.CredentialStrategyRuntime,
+	})
+	if err != nil {
+		t.Fatalf("Create(withCountry) error = %v", err)
+	}
+	if err := serverRepo.UpdateCountry(ctx, withCountry.ID, "JP", "Japan"); err != nil {
+		t.Fatalf("UpdateCountry() error = %v", err)
+	}
+
+	noCountry, err := serverRepo.Create(ctx, servers.Server{
+		Name:               "private-1",
+		Host:               "10.0.0.5",
+		Port:               22,
+		AuthMode:           servers.AuthModePassword,
+		Username:           "ubuntu",
+		CredentialStrategy: servers.CredentialStrategyRuntime,
+	})
+	if err != nil {
+		t.Fatalf("Create(noCountry) error = %v", err)
+	}
+
+	// One metric snapshot and one current-month vnstat snapshot per server.
+	month := time.Now().UTC().Format("2006-01")
+	monthlyJSON := `[{"label":"` + month + `","rx_bytes":100,"tx_bytes":200,"total_bytes":300}]`
+	for _, id := range []int64{withCountry.ID, noCountry.ID} {
+		if _, err := runtime.SQL.ExecContext(ctx,
+			`INSERT INTO system_snapshots (server_id, cpu_usage, ram_usage, disk_usage) VALUES (?, ?, ?, ?)`,
+			id, 50.0, 40.0, 30.0,
+		); err != nil {
+			t.Fatalf("insert system_snapshots: %v", err)
+		}
+		if _, err := runtime.SQL.ExecContext(ctx,
+			`INSERT INTO vnstat_snapshots (server_id, available, monthly_rows_json) VALUES (?, 1, ?)`,
+			id, monthlyJSON,
+		); err != nil {
+			t.Fatalf("insert vnstat_snapshots: %v", err)
+		}
+	}
+
+	repo := analytics.NewSQLRepository(runtime.SQL)
+
+	metrics, err := repo.ListServerMetricSummaries(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListServerMetricSummaries() error = %v", err)
+	}
+	assertCountryCode(t, "metrics", collectMetricCountries(metrics), withCountry.ID, noCountry.ID)
+
+	traffic, err := repo.ListServerTrafficSummaries(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListServerTrafficSummaries() error = %v", err)
+	}
+	assertCountryCode(t, "traffic", collectTrafficCountries(traffic), withCountry.ID, noCountry.ID)
+}
+
+func collectMetricCountries(rows []analytics.ServerMetricSummary) map[int64]string {
+	out := make(map[int64]string, len(rows))
+	for _, r := range rows {
+		out[r.ServerID] = r.CountryCode
+	}
+	return out
+}
+
+func collectTrafficCountries(rows []analytics.ServerTrafficSummary) map[int64]string {
+	out := make(map[int64]string, len(rows))
+	for _, r := range rows {
+		out[r.ServerID] = r.CountryCode
+	}
+	return out
+}
+
+func assertCountryCode(t *testing.T, label string, codes map[int64]string, withCountryID, noCountryID int64) {
+	t.Helper()
+	if got := codes[withCountryID]; got != "JP" {
+		t.Errorf("%s: server with country code = %q, want %q", label, got, "JP")
+	}
+	if got := codes[noCountryID]; got != "" {
+		t.Errorf("%s: server without country code = %q, want empty", label, got)
+	}
+}

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -690,6 +690,10 @@ type AlertSilenceView struct {
 // AlertEventView renders one row in the alert history section.
 type AlertEventView struct {
 	ServerLabel string
+	// FlagEmoji is the event server's country flag (or "" when undetected);
+	// CountryName is shown on hover. Mirrors the servers-list badge.
+	FlagEmoji   string
+	CountryName string
 	MetricLabel string
 	Value       string
 	Threshold   string
@@ -838,18 +842,28 @@ type AnalyticsTargetView struct {
 type TopServerMetricView struct {
 	ServerID   int64
 	ServerName string
-	CPU        string
-	RAM        string
-	Disk       string
+	// FlagEmoji is the server's country flag (or "" when undetected); CountryName
+	// is shown on hover. Mirrors the servers-list badge so the overview stays
+	// visually consistent.
+	FlagEmoji   string
+	CountryName string
+	CPU         string
+	RAM         string
+	Disk        string
 }
 
 type TopServerTrafficView struct {
 	ServerID   int64
 	ServerName string
-	Download   string // current-month RX, human-readable
-	Upload     string // current-month TX, human-readable
-	MonthBytes string // current-month total, human-readable
-	MonthLabel string
+	// FlagEmoji is the server's country flag (or "" when undetected); CountryName
+	// is shown on hover. Mirrors the servers-list badge so the overview stays
+	// visually consistent.
+	FlagEmoji   string
+	CountryName string
+	Download    string // current-month RX, human-readable
+	Upload      string // current-month TX, human-readable
+	MonthBytes  string // current-month total, human-readable
+	MonthLabel  string
 }
 
 type GlobalAnalyticsView struct {

--- a/web/templates/alerts.gohtml
+++ b/web/templates/alerts.gohtml
@@ -208,7 +208,7 @@
         <tbody>
           {{ range .Events }}
           <tr>
-            <td>{{ .ServerLabel }}</td>
+            <td>{{ .ServerLabel }}{{ if .FlagEmoji }} <span class="server-flag" title="{{ .CountryName }}" aria-label="{{ .CountryName }}">{{ .FlagEmoji }}</span>{{ end }}</td>
             <td>{{ .MetricLabel }}</td>
             <td><code>{{ .Value }}</code></td>
             <td><code>{{ .Threshold }}</code></td>

--- a/web/templates/analytics.gohtml
+++ b/web/templates/analytics.gohtml
@@ -231,7 +231,7 @@
           <tr>
             <td class="server-name-cell">
               <i data-lucide="server" class="table-icon"></i>
-              {{ .ServerName }}
+              {{ .ServerName }}{{ if .FlagEmoji }} <span class="server-flag" title="{{ .CountryName }}" aria-label="{{ .CountryName }}">{{ .FlagEmoji }}</span>{{ end }}
             </td>
             <td class="text-right"><span class="metric-badge metric-badge--cpu">{{ .CPU }}</span></td>
             <td class="text-right"><span class="metric-badge metric-badge--ram">{{ .RAM }}</span></td>
@@ -268,7 +268,7 @@
           <tr>
             <td class="server-name-cell">
               <i data-lucide="server" class="table-icon"></i>
-              {{ .ServerName }}
+              {{ .ServerName }}{{ if .FlagEmoji }} <span class="server-flag" title="{{ .CountryName }}" aria-label="{{ .CountryName }}">{{ .FlagEmoji }}</span>{{ end }}
             </td>
             <td class="text-right">
               <span class="traffic-badge traffic-badge--dl">{{ .Download }}</span>


### PR DESCRIPTION
Flow the detected country code from the server record through the analytics overview rows and the alerts recent-activity events so each shows the same flag badge as the servers list. The code is folded into the existing analytics joins and alerts ref load (no N+1), then turned into an emoji via the shared geoip helper at the view layer.