### PR TITLE
fix(pwa): lock installed app to portrait orientation

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -144,24 +144,42 @@ the login page (and any future redirect-based navigation is equally safe). A
 test asserts each shortcut target cleanly returns `303 → /login` rather than a
 404 or an empty body.
 
-### 11. Orientation: omitted so the OS rotation lock wins
+### 11. Orientation: locked to portrait, never rotates
 
-The manifest declares **no `orientation` member**. An explicit value — including
-the spec default `"any"` — makes an installed PWA request an orientation lock
-from the OS, which *overrides* the user's system rotation lock: a phone locked to
-portrait still force-rotates to landscape when turned sideways (the bug this
-fixes). Omitting the member requests no lock, so the platform's auto-rotate /
-rotation-lock setting governs the app — locked portrait stays portrait, and an
-unlocked device is free to rotate.
+The manifest declares **`"orientation": "portrait"`**. The app must stay upright:
+on a phone turned sideways it should not rotate to landscape at all, even when the
+device's system rotation lock is off. `"portrait"` is chosen over
+`"portrait-primary"` because it is the more broadly honoured value across Android
+Chromium installs while still keeping the app upright; `portrait-primary` would
+additionally forbid the (rarely auto-triggered) upside-down portrait but is no
+more reliable in practice. The earlier "omit the member so the OS rotation lock
+wins" approach was abandoned — it left rotation entirely to the device, which
+still let the installed app swing to landscape and did not satisfy the
+"never rotate" requirement.
 
-We deliberately did **not** use `"portrait"` or `"natural"`: both *force* a fixed
-orientation rather than respecting the user's choice, and would prevent using the
-in-browser SSH terminal in landscape. There is **no per-page terminal exception**
-— a page-level `screen.orientation.lock()` would need fullscreen, add client JS
-against the minimal-`web/static` constraint, and would fight a hard rotation lock,
-reintroducing the original complaint. With orientation omitted the terminal
-already rotates to landscape whenever the user has rotation unlocked, which covers
-the long-line use case without overriding anyone's lock.
+**Defence-in-depth runtime lock.** Because some browsers/installs do not fully
+honour the manifest field, `app.js` (`initOrientationLock`) also calls
+`screen.orientation.lock('portrait')` at boot. It is strictly best-effort and
+fully feature-detected: the API is absent on iOS Safari (so the call is skipped),
+and Chromium only permits the lock for an installed/fullscreen app (so the
+returned Promise can reject). Every path is wrapped so a failure is swallowed and
+**never throws or breaks the page**. This adds a small, self-contained snippet to
+`web/static`, justified by the reliability win on platforms that ignore the
+manifest member.
+
+**The terminal.** There is no longer a landscape exception for the in-browser SSH
+terminal — it runs in portrait like everything else. The terminal's
+`orientationchange` listener (`terminal.js`) is now effectively a no-op on locked
+clients (orientation no longer changes) but is kept as a harmless safety net: if
+any browser still allows a flip, the xterm grid reflows correctly rather than
+being left mis-sized. The bfcache scroll-lock release on `pagehide` is unaffected.
+
+**iOS caveat.** iOS Safari has historically ignored the manifest `orientation`
+field for home-screen PWAs and exposes no `screen.orientation.lock()`, so neither
+mechanism can *force* portrait there — on iOS the app follows the device's own
+rotation behaviour. The runtime lock therefore buys us nothing on iOS; it is the
+Android/Chromium path that benefits. The manifest value remains correct and
+harmless on iOS.
 
 Note: installed PWAs cache the manifest, so an already-installed app must be
 **reinstalled** (or its manifest cache cleared) before this change takes effect.

--- a/internal/http/handlers/pwa.go
+++ b/internal/http/handlers/pwa.go
@@ -53,13 +53,15 @@ type webManifest struct {
 	StartURL    string `json:"start_url"`
 	Scope       string `json:"scope"`
 	Display     string `json:"display"`
-	// Orientation is deliberately omitted. Declaring an explicit value (notably
-	// "any") makes an installed PWA request an orientation lock from the OS,
-	// which overrides the user's system rotation lock and force-rotates the app
-	// even when they have locked portrait. With no orientation member the
-	// platform's auto-rotate / rotation-lock setting governs the app: locked
-	// portrait stays portrait, and an unlocked device is free to rotate (so the
-	// SSH terminal can still be used in landscape when the user allows it).
+	// Orientation locks the installed PWA to portrait so it never rotates to
+	// landscape — not even when the phone is turned sideways with the system
+	// rotation lock off. "portrait" (rather than "portrait-primary") is the most
+	// broadly honoured value across Android Chrome installs and keeps the app
+	// upright. Note: this manifest member is honoured by installed PWAs on
+	// Android/Chromium; iOS Safari historically ignores the orientation field, so
+	// a runtime screen.orientation.lock('portrait') call backs it up where the
+	// platform supports it (see web/static/app.js).
+	Orientation     string             `json:"orientation"`
 	ThemeColor      string             `json:"theme_color"`
 	BackgroundColor string             `json:"background_color"`
 	Lang            string             `json:"lang"`
@@ -85,6 +87,7 @@ func NewManifestHandler(cfg config.Config) ManifestHandler {
 		StartURL:        "/",
 		Scope:           "/",
 		Display:         "standalone",
+		Orientation:     "portrait",
 		ThemeColor:      "#0f172a",
 		BackgroundColor: "#0f172a",
 		Lang:            "en",

--- a/internal/http/pwa_test.go
+++ b/internal/http/pwa_test.go
@@ -101,12 +101,12 @@ func TestManifestServedPublicly(t *testing.T) {
 	}
 }
 
-// TestManifestRespectsRotationLock verifies the manifest does not declare an
-// orientation lock. An explicit orientation (notably "any") makes an installed
-// PWA override the device's system rotation lock and force-rotate even when the
-// user has locked portrait. Omitting the member hands control back to the OS
-// auto-rotate / rotation-lock setting, which is the behaviour we want.
-func TestManifestRespectsRotationLock(t *testing.T) {
+// TestManifestLocksPortrait verifies the manifest locks the installed PWA to
+// portrait so it never rotates to landscape — not even when the phone is turned
+// sideways with the system rotation lock off. The value must be exactly
+// "portrait"; the runtime screen.orientation.lock('portrait') call in app.js
+// backs this up where the platform honours it.
+func TestManifestLocksPortrait(t *testing.T) {
 	server := newPWATestServer(t)
 
 	resp := mustGet(t, server.URL+"/manifest.webmanifest")
@@ -117,9 +117,9 @@ func TestManifestRespectsRotationLock(t *testing.T) {
 		t.Fatalf("decode manifest: %v", err)
 	}
 
-	if v, ok := manifest["orientation"]; ok {
-		t.Fatalf("manifest declares orientation=%v; it must be omitted so the "+
-			"installed PWA honours the device rotation lock", v)
+	if got := manifest["orientation"]; got != "portrait" {
+		t.Fatalf("manifest orientation = %v, want \"portrait\" so the installed "+
+			"PWA stays locked to portrait and never rotates", got)
 	}
 }
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1178,6 +1178,30 @@
     });
   }
 
+  /* ── Lock screen orientation to portrait (PWA) ──────────────
+   * Defence-in-depth for the manifest `orientation: "portrait"` member: where
+   * the platform supports the Screen Orientation API we also lock at runtime, so
+   * installs/browsers that don't fully honour the manifest field still stay
+   * upright. This is strictly best-effort — screen.orientation.lock() rejects (a
+   * Promise) or throws on platforms where it is unavailable or not permitted
+   * (iOS Safari has no lock(); Chromium only allows it for an installed/
+   * fullscreen app), so every path is feature-detected and swallowed. A failure
+   * here must never surface an error or break the page.
+   */
+  function initOrientationLock() {
+    try {
+      var so = window.screen && window.screen.orientation;
+      if (!so || typeof so.lock !== 'function') return; // e.g. iOS Safari
+      var p = so.lock('portrait');
+      // Spec returns a Promise; older shims may return undefined or throw.
+      if (p && typeof p.catch === 'function') {
+        p.catch(function () { /* not allowed (not installed/fullscreen) — ignore */ });
+      }
+    } catch (err) {
+      /* unsupported / not permitted — fail silently */
+    }
+  }
+
   /* ── Boot ───────────────────────────────────────────────── */
   function boot() {
     renderIcons();
@@ -1203,6 +1227,7 @@
     initCollapsibles();
     initAdvancedToggle();
     initServiceWorker();
+    initOrientationLock();
     renderIcons(); // pick up icons injected by the steps above
   }
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -17,7 +17,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'v2';
+var CACHE_VERSION = 'v3';
 var STATIC_CACHE = 'nodexia-static-' + CACHE_VERSION;
 var OFFLINE_URL = '/static/offline.html';
 

--- a/web/static/terminal.js
+++ b/web/static/terminal.js
@@ -546,6 +546,12 @@
       vv.addEventListener('resize', scheduleViewportUpdate);
       vv.addEventListener('scroll', scheduleViewportUpdate);
     }
+    // The app is locked to portrait (manifest orientation + app.js runtime lock),
+    // so orientationchange should no longer fire on installed/locked clients —
+    // this listener is now effectively a no-op there. It is kept as a harmless
+    // safety net for any browser that still allows a rotation (e.g. a desktop
+    // tab, or a platform that ignores the lock): if the viewport ever does flip,
+    // the grid still reflows correctly instead of being left mis-sized.
     window.addEventListener('orientationchange', function () {
       setTimeout(scheduleViewportUpdate, 250);
     });


### PR DESCRIPTION
Set manifest orientation to "portrait" and add a best-effort runtime screen.orientation.lock('portrait') in app.js so the installed PWA stays upright and never rotates to landscape. The runtime lock is feature-detected and swallowed so it cannot throw on iOS Safari or when not installed.