### PR TITLE
fix(ui): fix rtl metric ordering, gauge scale and server count

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -3703,3 +3703,32 @@ html[lang="fa"] {
   direction: ltr;
   unicode-bidi: isolate;
 }
+
+/* Measurement values pair a number with a Latin unit (e.g. "56 TiB",
+   "2.1 GiB / 11.7 GiB", "↓ 5 ↑ 3 Mbps"). Under an RTL base direction the unit
+   and number get reordered to the visually wrong "TiB 56", so every value
+   surface is forced LTR + isolated, mirroring the code rule above. */
+[dir="rtl"] .gauge__value,
+[dir="rtl"] .gauge__detail,
+[dir="rtl"] .metric-strip__value,
+[dir="rtl"] .badge--load,
+[dir="rtl"] .traffic-bw__value,
+[dir="rtl"] .traffic-row__rx,
+[dir="rtl"] .traffic-row__tx,
+[dir="rtl"] .traffic-row__total,
+[dir="rtl"] .mini-metric__value,
+[dir="rtl"] .mini-bw-stat__value,
+[dir="rtl"] .traffic-summary__value,
+[dir="rtl"] .metric-badge,
+[dir="rtl"] .traffic-badge {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* The semicircular gauges fill from the geometric left (0%) to the right
+   (100%), so their 0 / 100 scale must stay pinned that way too. Letting the
+   flex row mirror under RTL swaps the labels onto the wrong ends, making a low
+   reading look like it sits next to "100". */
+[dir="rtl"] .gauge__scale {
+  direction: ltr;
+}

--- a/web/static/terminal.js
+++ b/web/static/terminal.js
@@ -96,6 +96,21 @@
 
   term.open(container);
 
+  /* ── Soft-keyboard hardening ──────────────────────────── */
+  // xterm's helper <textarea> already disables autocorrect/autocapitalize/
+  // spellcheck, but not autocomplete. Mobile keyboards (notably Gboard) keep a
+  // predictive "composing" region active and will re-insert a whole suggested
+  // word as you keep typing — e.g. "rebecca-" silently becomes
+  // "rebecca-rebecca". Turning autocomplete off and forcing plain Latin input
+  // (no smart prediction) stops the duplicated keystrokes.
+  if (term.textarea) {
+    term.textarea.setAttribute('autocomplete', 'off');
+    term.textarea.setAttribute('autocorrect', 'off');
+    term.textarea.setAttribute('autocapitalize', 'none');
+    term.textarea.setAttribute('spellcheck', 'false');
+    term.textarea.setAttribute('inputmode', 'text');
+  }
+
   /* ── Fit helper ───────────────────────────────────────── */
   function fitAndResize() {
     if (fitAddon) {

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -6,7 +6,7 @@
     <div class="kpi-card">
       <span class="kpi-card__icon"><i data-lucide="server"></i></span>
       <div class="kpi-card__body">
-        <span class="kpi-card__value">{{ len .DashboardSnapshots }}</span>
+        <span class="kpi-card__value">{{ .DashboardSnapshotTotal }}</span>
         <span class="kpi-card__label">{{ t "home.kpi.monitored_servers" }}</span>
       </div>
     </div>


### PR DESCRIPTION
- force LTR isolation on measurement values (TiB/GiB/Mbps) so the number leads the unit under RTL instead of rendering as 'TiB 56'
- pin gauge 0/100 scale LTR so a low reading no longer sits by '100'
- dashboard 'monitored servers' KPI counts all servers, not just the current page (max 5)
- disable mobile keyboard autocomplete on the terminal textarea to stop predictive text duplicating input (e.g. 'rebecca-' -> 'rebecca-rebecca')

https://claude.ai/code/session_014K2wVPZ4THCDkmExihjNbR