### PR TITLE
perf(http): add etag + cache-control to static assets

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -1,6 +1,9 @@
 package webhttp
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -104,17 +107,54 @@ func NewRouter(cfg config.Config, database *db.Runtime, sshService *sshclient.Se
 	)
 }
 
-// staticAssetHandler serves the embedded /static tree. Font files are
-// immutable — their content never changes under a given name — so they are
-// served with a one-year immutable cache directive to avoid revalidation on
-// every navigation. Other assets (CSS/JS) are left to the service worker's
-// stale-while-revalidate strategy and normal validators.
+// staticAssetHandler serves the embedded /static tree with cache validators.
+//
+// The assets are embedded via go:embed, whose files report a zero modtime, so
+// net/http emits no Last-Modified or ETag and the browser cannot revalidate —
+// it re-downloads every asset on every navigation (a ~550 KB tax dominated by
+// lucide.min.js, painfully slow on mobile, e.g. when switching language). We
+// fix that by attaching a content-hash ETag to every file plus a Cache-Control
+// directive: fonts never change under a name so they are immutable for a year;
+// everything else is cached for an hour and then cheaply revalidated via the
+// ETag (a 304 instead of a full re-download). http.ServeContent honours the
+// pre-set ETag for If-None-Match, so conditional requests get the 304.
 func staticAssetHandler(staticFiles fs.FS) http.Handler {
+	etags := staticETags(staticFiles)
 	fileServer := http.StripPrefix("/static/", http.FileServer(http.FS(staticFiles)))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if etag := etags[strings.TrimPrefix(r.URL.Path, "/static/")]; etag != "" {
+			w.Header().Set("ETag", etag)
+		}
 		if strings.HasPrefix(r.URL.Path, "/static/fonts/") {
 			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			w.Header().Set("Cache-Control", "public, max-age=3600")
 		}
 		fileServer.ServeHTTP(w, r)
 	})
+}
+
+// staticETags precomputes a strong, content-derived ETag for every embedded
+// static file (keyed by its path relative to the static root, e.g. "style.css"
+// or "fonts/exo2-latin.woff2"). Hashing once at startup keeps request handling
+// allocation-free; the content is fixed for the life of the binary.
+func staticETags(staticFiles fs.FS) map[string]string {
+	etags := make(map[string]string)
+	_ = fs.WalkDir(staticFiles, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		f, openErr := staticFiles.Open(path)
+		if openErr != nil {
+			return nil
+		}
+		defer f.Close()
+		hash := sha256.New()
+		if _, copyErr := io.Copy(hash, f); copyErr != nil {
+			return nil
+		}
+		etags[path] = `"` + hex.EncodeToString(hash.Sum(nil)[:16]) + `"`
+		return nil
+	})
+	return etags
 }

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -164,3 +164,63 @@ func readBody(t *testing.T, resp *http.Response) string {
 	}
 	return string(data)
 }
+
+// TestStaticAssetCaching guards the cache validators on /static: every asset
+// must carry an ETag and a Cache-Control, fonts are immutable, and a matching
+// If-None-Match returns 304 (no re-download). Without these, embed.FS's zero
+// modtime leaves assets uncacheable and every navigation re-fetches them.
+func TestStaticAssetCaching(t *testing.T) {
+	cfg := testutil.TestConfig(t)
+	logging.Setup(cfg.Log)
+
+	renderer, err := view.NewRenderer()
+	if err != nil {
+		t.Fatalf("NewRenderer() error = %v", err)
+	}
+	staticFiles, err := assets.Static()
+	if err != nil {
+		t.Fatalf("Static() error = %v", err)
+	}
+	handler := webhttp.NewRouter(
+		cfg, testutil.OpenTestDB(t), sshclient.New(cfg.SSH, cfg.Security),
+		commandstream.New(0), nil, nil, renderer, staticFiles, nil,
+		registry.DefaultModules(),
+	)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	t.Run("css carries etag and revalidatable cache-control", func(t *testing.T) {
+		resp := mustGet(t, server.URL+"/static/style.css")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+		etag := resp.Header.Get("ETag")
+		if etag == "" {
+			t.Fatal("style.css missing ETag")
+		}
+		if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "max-age=3600") {
+			t.Fatalf("style.css Cache-Control = %q, want max-age=3600", cc)
+		}
+
+		// A conditional request with the same ETag must be answered 304.
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/static/style.css", nil)
+		req.Header.Set("If-None-Match", etag)
+		cond, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("conditional GET error = %v", err)
+		}
+		defer cond.Body.Close()
+		if cond.StatusCode != http.StatusNotModified {
+			t.Fatalf("conditional status = %d, want 304", cond.StatusCode)
+		}
+	})
+
+	t.Run("fonts are immutable", func(t *testing.T) {
+		resp := mustGet(t, server.URL+"/static/fonts/exo2-latin.woff2")
+		defer resp.Body.Close()
+		if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "immutable") {
+			t.Fatalf("font Cache-Control = %q, want immutable", cc)
+		}
+	})
+}

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -17,7 +17,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'v3';
+var CACHE_VERSION = 'v4';
 var STATIC_CACHE = 'nodexia-static-' + CACHE_VERSION;
 var OFFLINE_URL = '/static/offline.html';
 
@@ -28,8 +28,10 @@ var PRECACHE_URLS = [
   OFFLINE_URL,
   '/static/offline.js',
   '/static/style.css',
+  '/static/login.css',
   '/static/fonts/exo2-latin.woff2',
   '/static/app.js',
+  '/static/login.js',
   '/static/lucide.min.js',
   '/static/favicon.svg',
   '/static/icon-192.png',


### PR DESCRIPTION
Embedded /static files report a zero modtime, so net/http sent no validators and the browser re-downloaded every asset (~550KB, mostly lucide.min.js) on each navigation — slow on mobile, e.g. switching language on /login. Attach a content-hash ETag plus Cache-Control (fonts immutable, others max-age=3600 + revalidate), so repeat loads are cache hits or cheap 304s. Also precache login.css/login.js (sw v4).