### PR TITLE
refactor(nodes): attribute xray ports to the owning node process

### DIFF
--- a/internal/http/middleware/security_test.go
+++ b/internal/http/middleware/security_test.go
@@ -127,44 +127,6 @@ func TestSession_SkipsStaticPaths(t *testing.T) {
 	}
 }
 
-// --- CSRF middleware ---
-
-func buildCSRFRequest(t *testing.T, cfg config.Config, method, path string, withToken bool) *http.Request {
-	t.Helper()
-
-	// First get a real session ID via the Session middleware.
-	var sessionID, csrfToken string
-	sessionMW := middleware.Session(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sessionID = middleware.GetSessionID(r.Context())
-		csrfToken = middleware.GetCSRFToken(r.Context())
-	}))
-	sessionMW.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
-
-	// Get the session cookie value from a recorder.
-	recInit := httptest.NewRecorder()
-	sessionMW.ServeHTTP(recInit, httptest.NewRequest(http.MethodGet, "/", nil))
-	var sessionCookieVal string
-	for _, c := range recInit.Result().Cookies() {
-		if c.Name == cfg.Security.SessionCookieName {
-			sessionCookieVal = c.Value
-		}
-	}
-
-	// Build the POST request.
-	form := url.Values{}
-	if withToken {
-		form.Set("_csrf_token", csrfToken)
-	}
-	req := httptest.NewRequest(method, path, strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Origin", "http://example.com")
-	req.Host = "example.com"
-	req.AddCookie(&http.Cookie{Name: cfg.Security.SessionCookieName, Value: sessionCookieVal})
-
-	_ = sessionID
-	return req
-}
-
 func TestCSRF_AllowsSafeMethods(t *testing.T) {
 	cfg := testConfig()
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })

--- a/internal/module/commands/handlers.go
+++ b/internal/module/commands/handlers.go
@@ -538,10 +538,6 @@ func defaultFormInput(deps module.Dependencies) view.CommandFormView {
 	}
 }
 
-func commandsURL(serverID int64) string {
-	return "/servers/" + formatID(serverID) + "/commands"
-}
-
 func formInputFromRequest(r *http.Request, deps module.Dependencies) FormInput {
 	return FormInput{
 		Intent:         strings.TrimSpace(r.FormValue("intent")),

--- a/internal/module/nodes/pasarguard.go
+++ b/internal/module/nodes/pasarguard.go
@@ -78,11 +78,15 @@ func (PasarGuardProvider) DiscoveryCommand() string {
 		`state=""; ` +
 		`[ "$HAVE_DOCKER" -eq 1 ] && state="$($SUDO docker inspect -f "{{.State.Status}}" "$cname" 2>/dev/null)"; ` +
 		`printf "=STATE=%s=\n" "$state"; ` +
+		// Host PIDs of this container's processes, used to attribute host-visible
+		// xray listeners (host networking) to this node specifically.
+		`PIDS=""; if [ "$HAVE_DOCKER" -eq 1 ]; then PIDS="$($SUDO docker top "$cname" -eo pid 2>/dev/null | tr "\n" " " || true)"; fi; ` +
+		`printf "=PIDS=%s=\n" "$PIDS"; ` +
 		`printf "=ENVSTART=\n"; cat "$dir/.env" 2>/dev/null || true; printf "\n=ENVEND=\n"; ` +
 		`printf "=PGNODEEND=\n"; ` +
 		`done; ` +
-		// Host-wide listening ports so host-networked nodes' xray inbounds are
-		// caught even when they are not published container ports.
+		// Host listening sockets with owning PIDs (once), matched per instance
+		// against its container PIDs to attribute host-networked xray inbounds.
 		listenProbeCommand +
 		`true'`
 }
@@ -98,6 +102,7 @@ type pgInstance struct {
 	ComposeLine   string
 	DataDir       string
 	State         string // `docker inspect` .State.Status (running/exited/…), or ""
+	PIDs          string // host PIDs of the container's processes (`docker top`)
 	EnvLines      []string
 }
 
@@ -113,8 +118,8 @@ func (p PasarGuardProvider) ParseDiscovery(output string, collectedAt time.Time)
 	lines := strings.Split(output, "\n")
 	containers, dockerSeen := parseDockerSection(lines)
 	instances := parsePGInstances(lines)
-	listenSection, _ := markerSection(lines, "=LISTEN=", "=LISTENEND=")
-	listenPorts := parseListenPorts(listenSection)
+	listenLines, _ := markerSection(lines, "=LISTENP=", "=LISTENPEND=")
+	listenSockets := parseListenSockets(listenLines)
 
 	snapshots := make([]Snapshot, 0, len(instances))
 	seen := map[string]struct{}{}
@@ -125,7 +130,7 @@ func (p PasarGuardProvider) ParseDiscovery(output string, collectedAt time.Time)
 		if cn := strings.ToLower(strings.TrimSpace(inst.ContainerName)); cn != "" {
 			seen[cn] = struct{}{}
 		}
-		snapshots = append(snapshots, p.buildSnapshot(inst, containers, dockerSeen, listenPorts, collectedAt))
+		snapshots = append(snapshots, p.buildSnapshot(inst, containers, dockerSeen, listenSockets, collectedAt))
 	}
 
 	// Containers running a PasarGuard NODE image without a matching /opt
@@ -141,7 +146,7 @@ func (p PasarGuardProvider) ParseDiscovery(output string, collectedAt time.Time)
 			continue
 		}
 		seen[strings.ToLower(c.Name)] = struct{}{}
-		snapshots = append(snapshots, p.buildSnapshot(pgInstance{Name: c.Name}, containers, dockerSeen, listenPorts, collectedAt))
+		snapshots = append(snapshots, p.buildSnapshot(pgInstance{Name: c.Name}, containers, dockerSeen, listenSockets, collectedAt))
 	}
 
 	return snapshots
@@ -207,6 +212,8 @@ func parsePGInstances(lines []string) []pgInstance {
 			current.DataDir = strings.TrimSuffix(strings.TrimPrefix(line, "=DATADIR="), "=")
 		case strings.HasPrefix(line, "=STATE=") && strings.HasSuffix(line, "="):
 			current.State = strings.TrimSuffix(strings.TrimPrefix(line, "=STATE="), "=")
+		case strings.HasPrefix(line, "=PIDS=") && strings.HasSuffix(line, "="):
+			current.PIDs = strings.TrimSuffix(strings.TrimPrefix(line, "=PIDS="), "=")
 		case line == "=ENVSTART=":
 			inEnv = true
 		case line == "=ENVEND=":
@@ -218,7 +225,7 @@ func parsePGInstances(lines []string) []pgInstance {
 	return instances
 }
 
-func (PasarGuardProvider) buildSnapshot(inst pgInstance, containers map[string]dockerEntry, dockerSeen bool, listenPorts []string, collectedAt time.Time) Snapshot {
+func (PasarGuardProvider) buildSnapshot(inst pgInstance, containers map[string]dockerEntry, dockerSeen bool, listenSockets []listenSocket, collectedAt time.Time) Snapshot {
 	env := parseEnvFile(inst.EnvLines)
 	// Look the container up by its real name, not the install directory name.
 	lookup := strings.ToLower(strings.TrimSpace(inst.ContainerName))
@@ -274,11 +281,11 @@ func (PasarGuardProvider) buildSnapshot(inst pgInstance, containers map[string]d
 	}
 
 	activePorts := uniqueStrings([]string{servicePort, apiPort})
-	// Published container ports (bridge networking) plus host listeners
-	// (host networking / binary), minus the management ports.
+	// Published container ports (bridge networking) plus the container's own
+	// host-visible listeners (host networking), minus the management ports.
 	xrayPorts := uniqueStrings(append(
 		containerXrayPorts(container.Ports, activePorts),
-		xrayPortsFromListen(listenPorts, servicePort, apiPort)...,
+		xrayPortsForPIDs(listenSockets, parsePIDs(inst.PIDs), servicePort, apiPort)...,
 	))
 	sortPortsNumeric(xrayPorts)
 

--- a/internal/module/nodes/provider.go
+++ b/internal/module/nodes/provider.go
@@ -206,15 +206,6 @@ func containsString(values []string, target string) bool {
 	return false
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v = strings.TrimSpace(v); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 func uniqueStrings(values []string) []string {
 	out := make([]string, 0, len(values))
 	seen := map[string]struct{}{}

--- a/internal/module/nodes/rebecca.go
+++ b/internal/module/nodes/rebecca.go
@@ -111,13 +111,19 @@ func (RebeccaProvider) DiscoveryCommand() string {
 		`printf "=RELEASESTART=\n"; $SUDO cat "$base/.binary-release.json" 2>/dev/null || true; printf "\n=RELEASEEND=\n"; ` +
 		`printf "=MODE=%s=\n" "$($SUDO cat "$base/.install-mode" 2>/dev/null)"; ` +
 		`printf "=SERVICE=%s=\n" "$(systemctl is-active "$name" 2>/dev/null)"; ` +
+		// PIDs owned by this instance's systemd service (the node agent and its
+		// xray child share the unit cgroup), so xray ports can be attributed to it
+		// rather than to every listener on the host.
+		`cg="$(systemctl show -p ControlGroup --value "$name" 2>/dev/null || true)"; ` +
+		`PIDS=""; if [ -n "$cg" ] && [ -r "/sys/fs/cgroup$cg/cgroup.procs" ]; then PIDS="$($SUDO cat "/sys/fs/cgroup$cg/cgroup.procs" 2>/dev/null | tr "\n" " " || true)"; fi; ` +
+		`printf "=PIDS=%s=\n" "$PIDS"; ` +
 		`if [ "$HAVE_DOCKER" -eq 1 ]; then ` +
 		`printf "=CONTAINER=%s=\n" "$($SUDO docker ps -a --filter "name=^${name}$" --format "{{.Status}}" 2>/dev/null | head -n 1)"; ` +
 		`fi; ` +
 		`printf "=REBECCANODEEND=\n"; ` +
 		`done; ` +
-		// Host-wide listening ports (once, after the per-instance loop) so xray
-		// inbounds — which binary nodes listen on directly — can be surfaced.
+		// Host listening sockets with owning PIDs (once), matched per instance
+		// against the cgroup PIDs above to attribute xray ports precisely.
 		listenProbeCommand +
 		`true'`
 }
@@ -125,9 +131,10 @@ func (RebeccaProvider) DiscoveryCommand() string {
 func (RebeccaProvider) ParseDiscovery(output string, collectedAt time.Time) []Snapshot {
 	lines := strings.Split(output, "\n")
 
-	// Host-wide listening ports, shared by every instance on the host.
-	listenSection, _ := markerSection(lines, "=LISTEN=", "=LISTENEND=")
-	listenPorts := parseListenPorts(listenSection)
+	// Host listening sockets (with owning PIDs), shared by every instance; each
+	// instance keeps only the ports owned by its own PIDs.
+	listenLines, _ := markerSection(lines, "=LISTENP=", "=LISTENPEND=")
+	listenSockets := parseListenSockets(listenLines)
 
 	var snapshots []Snapshot
 	var name string
@@ -143,7 +150,7 @@ func (RebeccaProvider) ParseDiscovery(output string, collectedAt time.Time) []Sn
 			inBlock = true
 		case trimmed == "=REBECCANODEEND=":
 			if inBlock && name != "" {
-				snapshots = append(snapshots, parseRebeccaInstance(name, block, listenPorts, collectedAt))
+				snapshots = append(snapshots, parseRebeccaInstance(name, block, listenSockets, collectedAt))
 			}
 			inBlock = false
 			name = ""
@@ -159,7 +166,7 @@ func (RebeccaProvider) ParseDiscovery(output string, collectedAt time.Time) []Sn
 // parseRebeccaInstance builds one Snapshot from a single "=REBECCANODE=" block.
 // name is the /opt/<name> directory (and systemd/container name) the instance
 // lives under.
-func parseRebeccaInstance(name string, lines []string, listenPorts []string, collectedAt time.Time) Snapshot {
+func parseRebeccaInstance(name string, lines []string, listenSockets []listenSocket, collectedAt time.Time) Snapshot {
 	envLines, _ := markerSection(lines, "=ENVSTART=", "=ENVEND=")
 	env := parseEnvFile(envLines)
 
@@ -216,8 +223,11 @@ func parseRebeccaInstance(name string, lines []string, listenPorts []string, col
 		confidence = "high"
 	}
 
-	// Xray inbounds = public listeners minus the node's own service/api ports.
-	xrayPorts := xrayPortsFromListen(listenPorts, servicePort, apiPort)
+	// Xray inbounds = ports owned by this instance's PIDs, minus its own
+	// service/api management ports.
+	pidsRaw, _ := markerValue(lines, "PIDS")
+	nodePIDs := parsePIDs(pidsRaw)
+	xrayPorts := xrayPortsForPIDs(listenSockets, nodePIDs, servicePort, apiPort)
 
 	return normalizeSnapshot(Snapshot{
 		NodeType:     rebeccaType,

--- a/internal/module/nodes/xrayports.go
+++ b/internal/module/nodes/xrayports.go
@@ -6,81 +6,142 @@ import (
 	"strings"
 )
 
-// listenProbeCommand is appended to a provider's discovery command to capture
-// the host's listening TCP ports in one pass. Xray inbounds (binary and
-// host-networked nodes) listen here, so the parser can surface them as xray
-// ports. `ss` is preferred; netstat is the portable fallback. The output is
-// wrapped in =LISTEN=…=LISTENEND= so ParseDiscovery can isolate it.
-const listenProbeCommand = `printf "=LISTEN=\n"; ` +
-	`($SUDO ss -tlnH 2>/dev/null || $SUDO ss -tln 2>/dev/null || $SUDO netstat -tln 2>/dev/null || true); ` +
-	`printf "=LISTENEND=\n"; `
+// Xray inbound-port detection.
+//
+// A node's xray ports are the public TCP ports its OWN xray process listens on
+// — not every port open on the host. Attributing ports to a specific node
+// matters because one host can run several nodes (plus SSH, DNS, web servers…),
+// and a host-wide port list would wrongly show all of them on every node.
+//
+// We attribute by process ownership: discovery captures `ss -tlnp` (listening
+// sockets WITH their owning PIDs) once per host, and each node block carries the
+// set of PIDs that belong to it — systemd cgroup members for binary installs,
+// `docker top` for containers. A socket counts as the node's xray port only when
+// its PID is one of the node's, minus the node's own management (service/api)
+// ports. PasarGuard additionally unions the published container ports so bridge
+// networking (where the listener is docker-proxy, not the container) still works.
 
-// wellKnownNonXrayPorts are public listeners that are never xray inbounds, so
-// they are excluded from the detected xray ports (SSH and DNS).
-var wellKnownNonXrayPorts = map[string]struct{}{
-	"22": {}, // SSH
-	"53": {}, // DNS
+// listenProbeCommand captures the host's listening TCP sockets with owning
+// process info, wrapped in =LISTENP=…=LISTENPEND=. `-H` drops the header; the
+// plain form is the fallback. `-p` needs root/sudo to reveal other processes,
+// which discovery already runs with.
+const listenProbeCommand = `printf "=LISTENP=\n"; ` +
+	`($SUDO ss -tlnpH 2>/dev/null || $SUDO ss -tlnp 2>/dev/null || true); ` +
+	`printf "=LISTENPEND=\n"; `
+
+// listenSocket is one listening TCP socket: its port and the PIDs that own it.
+type listenSocket struct {
+	Port string
+	PIDs []string
 }
 
-// parseListenPorts extracts the publicly reachable TCP listening ports from
-// `ss -tln` / `netstat -tln` output. Loopback-only listeners (127.0.0.0/8, ::1)
-// are dropped since they are node-internal, as is the header row. Ports are
-// returned unique and numerically sorted.
-func parseListenPorts(lines []string) []string {
-	seen := map[string]struct{}{}
-	var ports []string
+// parseListenSockets parses `ss -tlnp` output into public listening sockets.
+// Loopback-only listeners (127.0.0.0/8, ::1) and the header row are dropped.
+func parseListenSockets(lines []string) []listenSocket {
+	var out []listenSocket
 	for _, raw := range lines {
 		fields := strings.Fields(raw)
 		if len(fields) < 4 {
 			continue
 		}
-		// `State Recv-Q Send-Q Local:Port Peer:Port …` — field[3] is the local
-		// address. ss may also prefix an interface ("%lo"); LastIndex(":") still
-		// isolates the port.
+		// `State Recv-Q Send-Q Local:Port Peer:Port users:((…))` — field[3] is the
+		// local address; a trailing "%iface"/zone is handled by LastIndex(":").
 		addr := fields[3]
 		idx := strings.LastIndex(addr, ":")
 		if idx < 0 {
 			continue
 		}
 		host, port := addr[:idx], addr[idx+1:]
-		if !isAllDigits(port) || port == "" || port == "0" {
+		if !isAllDigits(port) || port == "0" {
 			continue // header row or malformed
 		}
 		if isLoopbackHost(host) {
 			continue
 		}
-		if _, ok := seen[port]; ok {
-			continue
-		}
-		seen[port] = struct{}{}
-		ports = append(ports, port)
+		out = append(out, listenSocket{Port: port, PIDs: extractPIDs(raw)})
 	}
-	sortPortsNumeric(ports)
-	return ports
+	return out
 }
 
-// xrayPortsFromListen returns the listening ports that look like xray inbounds:
-// every public listener minus the well-known system ports and the node's own
-// management ports (service/api), which are surfaced separately.
-func xrayPortsFromListen(listen []string, exclude ...string) []string {
-	if len(listen) == 0 {
+// extractPIDs pulls every pid=N from an `ss -tlnp` process column, e.g.
+// users:(("xray",pid=1234,fd=7),("xray",pid=1234,fd=8)).
+func extractPIDs(line string) []string {
+	var pids []string
+	for {
+		i := strings.Index(line, "pid=")
+		if i < 0 {
+			break
+		}
+		line = line[i+len("pid="):]
+		j := 0
+		for j < len(line) && line[j] >= '0' && line[j] <= '9' {
+			j++
+		}
+		if j > 0 {
+			pids = append(pids, line[:j])
+		}
+		line = line[j:]
+	}
+	return pids
+}
+
+// xrayPortsForPIDs returns the ports whose owning PID is one of the node's,
+// excluding its management ports (service/api). Result is unique and numerically
+// sorted. An empty PID set yields no ports (so a node we cannot attribute simply
+// shows none rather than the whole host).
+func xrayPortsForPIDs(sockets []listenSocket, nodePIDs []string, exclude ...string) []string {
+	if len(nodePIDs) == 0 {
 		return nil
 	}
-	skip := map[string]struct{}{}
-	for k := range wellKnownNonXrayPorts {
-		skip[k] = struct{}{}
+	pidSet := make(map[string]struct{}, len(nodePIDs))
+	for _, p := range nodePIDs {
+		if p != "" {
+			pidSet[p] = struct{}{}
+		}
 	}
+	skip := map[string]struct{}{}
 	for _, e := range exclude {
 		if e = strings.TrimSpace(e); e != "" {
 			skip[e] = struct{}{}
 		}
 	}
+
+	seen := map[string]struct{}{}
 	var out []string
-	for _, p := range listen {
-		if _, ok := skip[p]; ok {
+	for _, s := range sockets {
+		if _, bad := skip[s.Port]; bad {
 			continue
 		}
-		out = append(out, p)
+		if _, dup := seen[s.Port]; dup {
+			continue
+		}
+		if !ownedBy(s.PIDs, pidSet) {
+			continue
+		}
+		seen[s.Port] = struct{}{}
+		out = append(out, s.Port)
+	}
+	sortPortsNumeric(out)
+	return out
+}
+
+func ownedBy(pids []string, set map[string]struct{}) bool {
+	for _, p := range pids {
+		if _, ok := set[p]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// parsePIDs extracts the numeric PIDs from a whitespace-separated list (cgroup
+// procs or `docker top` output), ignoring any header/non-numeric tokens.
+func parsePIDs(s string) []string {
+	var out []string
+	for _, f := range strings.Fields(s) {
+		if isAllDigits(f) {
+			out = append(out, f)
+		}
 	}
 	return out
 }

--- a/internal/module/nodes/xrayports_test.go
+++ b/internal/module/nodes/xrayports_test.go
@@ -8,56 +8,67 @@ import (
 	"time"
 )
 
-// ssSample is real `ss -tln` output from a Rebecca binary node (the node's own
-// ports are 62033/62034/62035; the rest of the public listeners are xray
-// inbounds). Loopback and DNS listeners must be dropped.
-const ssSample = `State   Recv-Q   Send-Q     Local Address:Port      Peer Address:Port  Process
-LISTEN  0        4096           127.0.0.1:14878          0.0.0.0:*
-LISTEN  0        4096           127.0.0.1:53234          0.0.0.0:*
-LISTEN  0        4096       127.0.0.53%lo:53             0.0.0.0:*
-LISTEN  0        4096          127.0.0.54:53             0.0.0.0:*
-LISTEN  0        4096             0.0.0.0:22             0.0.0.0:*
-LISTEN  0        4096                   *:5505                 *:*
-LISTEN  0        4096                   *:62033                *:*
-LISTEN  0        4096                   *:62034                *:*
-LISTEN  0        4096                   *:8443                 *:*
-LISTEN  0        4096                   *:2053                 *:*
-LISTEN  0        4096                [::]:22                [::]:*`
+// ssNP is `ss -tlnp` output for a host running two xray nodes plus system
+// services. The first node owns pids 1234 (xray) and 1200 (its agent, on the
+// management ports 62033/62034); a SECOND node's xray is pid 9999; sshd is pid
+// 700. Only the first node's xray inbound (5505) must be attributed to it.
+const ssNP = `LISTEN 0 4096 *:5505 *:* users:(("xray",pid=1234,fd=7))
+LISTEN 0 4096 *:8443 *:* users:(("xray",pid=1234,fd=9),("xray",pid=1234,fd=10))
+LISTEN 0 4096 *:62033 *:* users:(("rebecca-node",pid=1200,fd=3))
+LISTEN 0 4096 *:62034 *:* users:(("rebecca-node",pid=1200,fd=4))
+LISTEN 0 4096 *:880 *:* users:(("xray",pid=9999,fd=7))
+LISTEN 0 4096 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=700,fd=3))
+LISTEN 0 4096 127.0.0.1:9000 0.0.0.0:* users:(("agent",pid=1234,fd=9))`
 
-func TestParseListenPorts(t *testing.T) {
-	got := parseListenPorts(strings.Split(ssSample, "\n"))
-	want := []string{"22", "2053", "5505", "8443", "62033", "62034"}
+func TestParseListenSockets(t *testing.T) {
+	got := parseListenSockets(strings.Split(ssNP, "\n"))
+	// Loopback (127.0.0.1:9000) is dropped; the rest keep their PIDs.
+	want := []listenSocket{
+		{Port: "5505", PIDs: []string{"1234"}},
+		{Port: "8443", PIDs: []string{"1234", "1234"}},
+		{Port: "62033", PIDs: []string{"1200"}},
+		{Port: "62034", PIDs: []string{"1200"}},
+		{Port: "880", PIDs: []string{"9999"}},
+		{Port: "22", PIDs: []string{"700"}},
+	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("parseListenPorts() = %v, want %v", got, want)
+		t.Fatalf("parseListenSockets() = %#v, want %#v", got, want)
 	}
 }
 
-func TestXrayPortsFromListen(t *testing.T) {
-	listen := parseListenPorts(strings.Split(ssSample, "\n"))
-	// Exclude the node's service (62033) and api (62034) ports; 22 (SSH) and 53
-	// (DNS) are dropped as well-known non-xray.
-	got := xrayPortsFromListen(listen, "62033", "62034")
-	want := []string{"2053", "5505", "8443"}
+func TestXrayPortsForPIDs(t *testing.T) {
+	sockets := parseListenSockets(strings.Split(ssNP, "\n"))
+	// Node owns pids 1234 (xray) + 1200 (agent); exclude its mgmt ports.
+	got := xrayPortsForPIDs(sockets, []string{"1234", "1200"}, "62033", "62034")
+	want := []string{"5505", "8443"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("xrayPortsFromListen() = %v, want %v", got, want)
+		t.Fatalf("xrayPortsForPIDs() = %v, want %v (must exclude other node's 880, sshd 22, mgmt 62033/62034)", got, want)
+	}
+
+	// No PIDs → no ports (never fall back to the whole host).
+	if got := xrayPortsForPIDs(sockets, nil); got != nil {
+		t.Fatalf("xrayPortsForPIDs(nil pids) = %v, want nil", got)
 	}
 }
 
-func TestRebeccaDiscoverySurfacesXrayPorts(t *testing.T) {
-	output := "=REBECCANODE=rebecca-node=\n=ENVSTART=\nSERVICE_PORT=62033\nXRAY_API_PORT=62034\n=ENVEND=\n=RELEASESTART=\n=RELEASEEND=\n=MODE=binary=\n=SERVICE=active=\n=REBECCANODEEND=\n" +
-		"=LISTEN=\n" + ssSample + "\n=LISTENEND=\n"
+func TestRebeccaDiscoveryAttributesXrayPortsByPID(t *testing.T) {
+	output := "=REBECCANODE=rebecca-node=\n" +
+		"=ENVSTART=\nSERVICE_PORT=62033\nXRAY_API_PORT=62034\n=ENVEND=\n" +
+		"=RELEASESTART=\n=RELEASEEND=\n=MODE=binary=\n=SERVICE=active=\n" +
+		"=PIDS=1234 1200 =\n=REBECCANODEEND=\n" +
+		"=LISTENP=\n" + ssNP + "\n=LISTENPEND=\n"
 	snaps := RebeccaProvider{}.ParseDiscovery(output, time.Now())
 	if len(snaps) != 1 {
 		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
 	}
-	want := []string{"2053", "5505", "8443"}
+	want := []string{"5505", "8443"}
 	if !reflect.DeepEqual(snaps[0].XrayPorts, want) {
 		t.Fatalf("XrayPorts = %v, want %v", snaps[0].XrayPorts, want)
 	}
 }
 
-// TestDiscoveryCommandsShellSyntax guards the listening-port probe (and the rest
-// of each discovery command) against shell-syntax breakage and stray single
+// TestDiscoveryCommandsShellSyntax guards both discovery commands (including the
+// listening-port/PID probes) against shell-syntax breakage and stray single
 // quotes that would break the sh -c '…' wrapper.
 func TestDiscoveryCommandsShellSyntax(t *testing.T) {
 	for _, p := range DefaultProviders() {
@@ -66,7 +77,7 @@ func TestDiscoveryCommandsShellSyntax(t *testing.T) {
 			continue
 		}
 		if strings.Count(cmd, "'") != 2 {
-			t.Errorf("%s: discovery command should have exactly 2 single quotes (the wrapper): %s", p.Type(), cmd)
+			t.Errorf("%s: discovery command should have exactly 2 single quotes (the wrapper)", p.Type())
 		}
 		inner := strings.TrimSuffix(strings.TrimPrefix(cmd, "sh -c '"), "'")
 		c := exec.Command("sh", "-n")


### PR DESCRIPTION
The previous detection dumped every public host port onto every node. Now discovery captures ss -tlnp (sockets WITH owning PIDs) and each node block carries its PIDs — systemd cgroup members for binary installs, docker top for containers. A port is the node’s xray inbound only when a node PID owns it, minus the node management (service/api) ports; PasarGuard still unions published container ports for bridge networking.

Also remove dead code (firstNonEmpty, commandsURL, buildCSRFRequest).