### PR TITLE
feat(home): replace background jobs feed with node status

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -36,7 +36,6 @@
   "home.section.live_activity": "Live activity",
   "home.section.runtime_config": "Runtime & configuration",
   "home.card.resource_snapshots": "Resource snapshots",
-  "home.card.background_jobs": "Background jobs",
   "home.card.runtime": "Runtime",
   "home.card.collection_scheduler": "Collection scheduler",
   "home.card.route_groups": "Route groups",
@@ -62,21 +61,11 @@
   "home.metric.peak_download_title": "Peak download (RX) bandwidth. Upload is excluded so this lines up with the download-only port speed VPS providers advertise.",
   "home.meta.load": "Load {value}",
   "home.meta.up": "Up {value}",
-  "home.failures": {
-    "one": "{count} failure",
-    "other": "{count} failures"
-  },
-  "home.job.next": "Next {value}",
-  "home.job.last_ok": "Last OK {value}",
-  "home.more_jobs": {
-    "one": "And {count} more…",
-    "other": "And {count} more…"
-  },
   "home.empty.snapshots_title": "No snapshots yet",
   "home.empty.snapshots_desc": "Open a server's monitoring page and refresh it to start collecting resource snapshots.",
   "home.empty.go_to_servers": "Go to servers",
-  "home.empty.jobs_title": "No background jobs yet",
-  "home.empty.jobs_desc": "The scheduler populates this panel after its first sweep of registered servers.",
+  "home.empty.nodes_title": "No nodes discovered yet",
+  "home.empty.nodes_desc": "The scheduler lists Rebecca and PasarGuard nodes here after its first discovery sweep of registered servers.",
   "home.runtime.http_address": "HTTP address",
   "home.runtime.environment": "Environment",
   "home.runtime.version": "Version",

--- a/internal/i18n/locales/fa.json
+++ b/internal/i18n/locales/fa.json
@@ -36,7 +36,6 @@
   "home.section.live_activity": "رویدادهای زنده",
   "home.section.runtime_config": "محیط اجرا و پیکربندی",
   "home.card.resource_snapshots": "نماهای لحظه‌ای منابع",
-  "home.card.background_jobs": "کارهای پس‌زمینه",
   "home.card.runtime": "محیط اجرا",
   "home.card.collection_scheduler": "زمان‌بند جمع‌آوری",
   "home.card.route_groups": "گروه‌های مسیر",
@@ -62,21 +61,11 @@
   "home.metric.peak_download_title": "حداکثر پهنای باند دانلود (RX). آپلود لحاظ نشده تا با معیار سرعت پورت دانلود ارائه‌دهندگان VPS همخوان باشد.",
   "home.meta.load": "بار پردازشی: {value}",
   "home.meta.up": "آپتایم: {value}",
-  "home.failures": {
-    "one": "{count} خطا",
-    "other": "{count} خطا"
-  },
-  "home.job.next": "اجرای بعدی: {value}",
-  "home.job.last_ok": "آخرین موفقیت: {value}",
-  "home.more_jobs": {
-    "one": "و {count} مورد دیگر…",
-    "other": "و {count} مورد دیگر…"
-  },
   "home.empty.snapshots_title": "بدون نمای لحظه‌ای",
   "home.empty.snapshots_desc": "برای شروع جمع‌آوری داده‌های منابع، صفحه پایش یک سرور را باز کرده و بازخوانی کنید.",
   "home.empty.go_to_servers": "مدیریت سرورها",
-  "home.empty.jobs_title": "بدون کار پس‌زمینه",
-  "home.empty.jobs_desc": "این بخش پس از اولین پویش سرورها توسط زمان‌بند پر خواهد شد.",
+  "home.empty.nodes_title": "هنوز نودی کشف نشده",
+  "home.empty.nodes_desc": "زمان‌بند پس از اولین پویش کشف سرورها، نودهای Rebecca و PasarGuard را اینجا فهرست می‌کند.",
   "home.runtime.http_address": "آدرس HTTP",
   "home.runtime.environment": "محیط",
   "home.runtime.version": "نسخه",

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -108,52 +108,10 @@
 
     <article class="card">
       <div class="card__header">
-        <h3><i data-lucide="calendar-clock"></i> {{ t "home.card.background_jobs" }}</h3>
-        <span class="status-pill status-pill--{{ if .SchedulerOverview.Enabled }}ok{{ else }}idle{{ end }}">{{ if .SchedulerOverview.Enabled }}{{ t "home.scheduler.active" }}{{ else }}{{ t "home.scheduler.off" }}{{ end }}</span>
-      </div>
-      {{ if .SchedulerOverview.Jobs }}
-      <div class="dashboard-list dashboard-list--scrollable">
-        {{ range .SchedulerOverview.Jobs }}
-        <article class="dashboard-item">
-          <div class="server-item__header">
-            <h4><i data-lucide="server" class="icon-in-button"></i> {{ .ServerName }}{{ if .FlagEmoji }} <span class="server-flag" title="{{ .CountryName }}" aria-label="{{ .CountryName }}">{{ .FlagEmoji }}</span>{{ end }}</h4>
-            <span class="status-pill status-pill--{{ if or (eq .Status "running") (eq .Status "scheduled") }}ok{{ else if eq .Status "retrying" }}crit{{ else if eq .Status "blocked" }}warn{{ else }}idle{{ end }}">{{ .Status }}</span>
-          </div>
-          <div class="dashboard-item__meta">
-            <span><i data-lucide="layers"></i> {{ .JobType }}</span>
-            {{ if eq .JobType "monitoring" }}
-            <a class="btn btn--ghost btn--sm" href="/servers/{{ .ServerID }}/monitoring"><i data-lucide="gauge" class="icon-in-button"></i> {{ t "home.monitor" }}</a>
-            {{ else }}
-            <a class="btn btn--ghost btn--sm" href="/servers/{{ .ServerID }}/nodes"><i data-lucide="boxes" class="icon-in-button"></i> {{ t "home.nodes" }}</a>
-            {{ end }}
-          </div>
-          <div class="dashboard-item__meta">
-            <span><i data-lucide="timer"></i> {{ t "home.job.next" "value" .NextRunAt }}</span>
-            <span><i data-lucide="circle-check"></i> {{ t "home.job.last_ok" "value" .LastSuccessAt }}</span>
-            {{ if gt .ConsecutiveFailures 0 }}<span class="status-pill status-pill--crit"><i data-lucide="circle-alert" class="icon-in-button"></i> {{ tn "home.failures" .ConsecutiveFailures }}</span>{{ end }}
-          </div>
-          {{ if .LastError }}<p class="error-inline">{{ .LastError }}</p>{{ end }}
-        </article>
-        {{ end }}
-        {{ if gt .SchedulerOverview.MoreJobs 0 }}
-        <p class="dashboard-list__more"><i data-lucide="ellipsis"></i> {{ tn "home.more_jobs" .SchedulerOverview.MoreJobs }}</p>
-        {{ end }}
-      </div>
-      {{ else }}
-      <div class="empty-state-card">
-        <span class="empty-state-icon"><i data-lucide="calendar-clock"></i></span>
-        <p class="empty-state-title">{{ t "home.empty.jobs_title" }}</p>
-        <p class="empty-state-desc">{{ t "home.empty.jobs_desc" }}</p>
-      </div>
-      {{ end }}
-    </article>
-
-    {{ if .DashboardNodeStatus.Servers }}
-    <article class="card">
-      <div class="card__header">
         <h3><i data-lucide="boxes"></i> {{ t "home.card.node_status" }}</h3>
         {{ if .DashboardNodeStatus.HasStopped }}<span class="status-pill status-pill--crit"><i data-lucide="circle-alert" class="icon-in-button"></i> {{ t "home.node.attention" }}</span>{{ end }}
       </div>
+      {{ if .DashboardNodeStatus.Servers }}
       <div class="dashboard-list dashboard-list--scrollable">
         {{ range .DashboardNodeStatus.Servers }}
         <article class="dashboard-item">
@@ -170,8 +128,14 @@
         </article>
         {{ end }}
       </div>
+      {{ else }}
+      <div class="empty-state-card">
+        <span class="empty-state-icon"><i data-lucide="boxes"></i></span>
+        <p class="empty-state-title">{{ t "home.empty.nodes_title" }}</p>
+        <p class="empty-state-desc">{{ t "home.empty.nodes_desc" }}</p>
+      </div>
+      {{ end }}
     </article>
-    {{ end }}
   </div>
 
   <p class="dash-section"><i data-lucide="settings"></i> {{ t "home.section.runtime_config" }}</p>


### PR DESCRIPTION
The dashboard's live-activity feed showed a Background jobs card whose information (scheduler state, intervals, eligible/blocked counts) is already covered by the KPI row and the Collection scheduler config card below. Drop it and let the fleet Node status card take that slot, so the feed pairs resource snapshots with node health at a glance.

Node status now always renders (with an empty state before the first discovery sweep) instead of only when nodes exist. Removes the seven i18n keys the background-jobs card owned (en/fa parity kept) and adds the node empty-state strings.