### PR TITLE
fix(terminal): bust stale asset cache so popovers stay hidden

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -1,8 +1,12 @@
 package assets
 
 import (
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
+	"io"
 	"io/fs"
+	"sync"
 )
 
 var (
@@ -26,4 +30,43 @@ func Static() (fs.FS, error) {
 
 func Schema() string {
 	return schemaSQL
+}
+
+var (
+	staticVersionsOnce sync.Once
+	staticVersions     map[string]string
+)
+
+// StaticAssetVersion returns a short, content-derived fingerprint for a file
+// under web/static (named relative to the static root, e.g. "terminal.css"), or
+// "" if the file is unknown. It is meant to be appended as a cache-busting query
+// string (`/static/terminal.css?v=<fp>`): when a file's bytes change so does its
+// URL, which forces browsers AND the stale-while-revalidate service worker to
+// fetch the new copy instead of serving an old cached one — without any manual
+// version bump. Hashes are computed once and cached for the life of the binary.
+func StaticAssetVersion(name string) string {
+	staticVersionsOnce.Do(func() {
+		staticVersions = map[string]string{}
+		sub, err := fs.Sub(staticFiles, "web/static")
+		if err != nil {
+			return
+		}
+		_ = fs.WalkDir(sub, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			f, openErr := sub.Open(path)
+			if openErr != nil {
+				return nil
+			}
+			defer f.Close()
+			h := sha256.New()
+			if _, copyErr := io.Copy(h, f); copyErr != nil {
+				return nil
+			}
+			staticVersions[path] = hex.EncodeToString(h.Sum(nil)[:6])
+			return nil
+		})
+	})
+	return staticVersions[name]
 }

--- a/internal/module/terminal/handlers.go
+++ b/internal/module/terminal/handlers.go
@@ -60,6 +60,7 @@ import (
 
 	cwebsocket "github.com/coder/websocket"
 
+	assets "github.com/Ho3einK84/Nodexia"
 	"github.com/Ho3einK84/Nodexia/internal/http/httperrors"
 	"github.com/Ho3einK84/Nodexia/internal/http/middleware"
 	"github.com/Ho3einK84/Nodexia/internal/module"
@@ -521,25 +522,29 @@ func renderTerminalPage(
 	}
 	page.TerminalForm = form
 	page.TerminalTicket = ticketID
+	// Each asset URL carries a content-hash query string so a corrected
+	// terminal.css/js can never be shadowed by a stale service-worker cache: when
+	// a file changes, its URL changes, so the browser/SW must fetch the new copy
+	// (no version bump required). See assets.StaticAssetVersion.
 	page.PageStyles = []string{
-		"/static/xterm.min.css",
-		"/static/terminal.css",
+		staticURL("xterm.min.css"),
+		staticURL("terminal.css"),
 	}
 	// xterm.js core, then its addons, then the theme catalog and keybinding
 	// handler, then terminal.js (which orchestrates them). All vendored locally —
 	// the panel runs under a strict `script-src 'self'` CSP, so no CDN is used.
 	page.PageScripts = []string{
-		"/static/xterm.min.js",
-		"/static/xterm-addon-fit.min.js",
-		"/static/xterm-addon-unicode11.min.js",
-		"/static/xterm-addon-web-links.min.js",
-		"/static/xterm-addon-search.min.js",
-		"/static/xterm-addon-serialize.min.js",
-		"/static/xterm-addon-webgl.min.js",
-		"/static/xterm-addon-canvas.min.js",
-		"/static/xterm-themes.js",
-		"/static/terminal-keybindings.js",
-		"/static/terminal.js",
+		staticURL("xterm.min.js"),
+		staticURL("xterm-addon-fit.min.js"),
+		staticURL("xterm-addon-unicode11.min.js"),
+		staticURL("xterm-addon-web-links.min.js"),
+		staticURL("xterm-addon-search.min.js"),
+		staticURL("xterm-addon-serialize.min.js"),
+		staticURL("xterm-addon-webgl.min.js"),
+		staticURL("xterm-addon-canvas.min.js"),
+		staticURL("xterm-themes.js"),
+		staticURL("terminal-keybindings.js"),
+		staticURL("terminal.js"),
 	}
 
 	if err := deps.Renderer.Render(w, http.StatusOK, page); err != nil {
@@ -553,6 +558,16 @@ func pathServerID(r *http.Request) (int64, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+// staticURL builds a /static URL for name with a content-hash cache-busting
+// query string when one is available, so updated assets are never served stale
+// from a browser or service-worker cache.
+func staticURL(name string) string {
+	if v := assets.StaticAssetVersion(name); v != "" {
+		return "/static/" + name + "?v=" + v
+	}
+	return "/static/" + name
 }
 
 func terminalURL(serverID int64) string {

--- a/internal/module/terminal/handlers_test.go
+++ b/internal/module/terminal/handlers_test.go
@@ -208,6 +208,14 @@ func TestTerminalPageIncludesAddonsAndChrome(t *testing.T) {
 			t.Errorf("terminal page missing element %q", id)
 		}
 	}
+
+	// terminal.css / terminal.js must carry a content-hash cache-busting query so
+	// a corrected asset can never be shadowed by a stale service-worker cache.
+	for _, asset := range []string{"/static/terminal.css?v=", "/static/terminal.js?v="} {
+		if !strings.Contains(body, asset) {
+			t.Errorf("terminal page asset %q missing cache-busting version query", asset)
+		}
+	}
 }
 
 func TestTerminalWSRejectsCrossOrigin(t *testing.T) {

--- a/web/static/terminal.js
+++ b/web/static/terminal.js
@@ -37,6 +37,18 @@
   function T(key, params) { return window.nxT ? window.nxT(key, params) : key; }
   function noop() {}
 
+  // setShown drives an element's visibility through BOTH the `hidden` attribute
+  // (state / accessibility) AND an inline display style. An inline style beats
+  // any stylesheet rule, so a popover (theme menu, search bar, overlays) can
+  // never be left visible by a stale or buggy CSS rule — which is exactly what
+  // pinned the theme menu open before. `display` is the value to apply when
+  // shown; omit it to fall back to the stylesheet's own display.
+  function setShown(el, shown, display) {
+    if (!el) return;
+    el.hidden = !shown;
+    el.style.display = shown ? (display || '') : 'none';
+  }
+
   var card = document.getElementById('terminal-card');
   if (!card) return;
 
@@ -396,7 +408,7 @@
   function toggleThemeMenu(force) {
     if (!themeMenu) return;
     var show = typeof force === 'boolean' ? force : themeMenu.hidden;
-    themeMenu.hidden = !show;
+    setShown(themeMenu, show, 'flex');
     if (themeBtn) themeBtn.setAttribute('aria-expanded', show ? 'true' : 'false');
   }
   if (themeBtn) {
@@ -412,6 +424,8 @@
     }
   });
   buildThemeMenu();
+  // Force-hide at startup so a stale stylesheet can never leave it open.
+  setShown(themeMenu, false, 'flex');
 
   /* ── Fullscreen ───────────────────────────────────────── */
   function fsElement() {
@@ -473,13 +487,13 @@
   }
   function openSearch() {
     if (!searchBar) return;
-    searchBar.hidden = false;
+    setShown(searchBar, true, 'flex');
     if (searchInput) { searchInput.focus(); searchInput.select(); }
     if (searchInput && searchInput.value) runSearch(true);
   }
   function closeSearch() {
     if (!searchBar) return;
-    searchBar.hidden = true;
+    setShown(searchBar, false, 'flex');
     if (searchAddon && searchAddon.clearDecorations) try { searchAddon.clearDecorations(); } catch (e) {}
     term.focus();
   }
@@ -497,6 +511,8 @@
   bindClick('terminal-search-next', function () { runSearch(true); });
   bindClick('terminal-search-prev', function () { runSearch(false); });
   bindClick('terminal-search-close', closeSearch);
+  // Force-hide at startup so a stale stylesheet can never leave the bar showing.
+  setShown(searchBar, false, 'flex');
   if (searchCaseBtn) {
     searchCaseBtn.addEventListener('click', function () {
       caseSensitive = !caseSensitive;
@@ -538,7 +554,7 @@
   function buildContextMenu() {
     ctxMenu = document.createElement('div');
     ctxMenu.className = 'terminal-context-menu';
-    ctxMenu.hidden = true;
+    setShown(ctxMenu, false, 'flex');
     [
       { label: T('js.terminal.ctx_copy'),       fn: function () { doCopy(currentSelection(), null); } },
       { label: T('js.terminal.ctx_paste'),      fn: doPaste },
@@ -557,14 +573,14 @@
   }
   function showContextMenu(x, y) {
     if (!ctxMenu) buildContextMenu();
-    ctxMenu.hidden = false;
+    setShown(ctxMenu, true, 'flex');
     var rect = card.getBoundingClientRect();
     var mx = Math.min(x - rect.left, rect.width - 170);
     var my = Math.min(y - rect.top, rect.height - 10);
     ctxMenu.style.left = Math.max(0, mx) + 'px';
     ctxMenu.style.top = Math.max(0, my) + 'px';
   }
-  function hideContextMenu() { if (ctxMenu) ctxMenu.hidden = true; }
+  function hideContextMenu() { if (ctxMenu) setShown(ctxMenu, false, 'flex'); }
   if (!isMobile) {
     container.addEventListener('contextmenu', function (e) {
       e.preventDefault();
@@ -739,10 +755,10 @@
       container.appendChild(disconnectOverlay);
     }
     disconnectOverlay.querySelector('.terminal-disconnect__msg').textContent = message;
-    disconnectOverlay.hidden = false;
+    setShown(disconnectOverlay, true, 'flex');
   }
   function hideDisconnectOverlay() {
-    if (disconnectOverlay) disconnectOverlay.hidden = true;
+    if (disconnectOverlay) setShown(disconnectOverlay, false, 'flex');
   }
 
   /* ── Back button ──────────────────────────────────────── */


### PR DESCRIPTION
The v0.4.1 CSS fix was correct but never reached clients: terminal.css and terminal.js are served stale-while-revalidate by the service worker, and with the panel open as a PWA / many tabs the new worker never activates — so the old buggy stylesheet (where the theme menu and search bar were stuck visible) kept being used.

Fix it at the source so no cache can shadow a corrected asset:
- assets.StaticAssetVersion: content-hash fingerprint per static file.
- terminal page now loads every script/style as `/static/x?v=<hash>`, so a changed file gets a new URL and is always re-fetched fresh — no version bump or manual cache busting required.
- terminal.js drives the theme menu, search bar, disconnect and context popovers through inline display styles (setShown), which beat any stylesheet, and force-hides them on startup — so visibility can never again depend on a fragile CSS cascade.


Claude-Session: https://claude.ai/code/session_01GUrzp9tEoCna9rKMZeEKar