### PR TITLE
Nodexia v0.6.8 Security & Quality Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/);
 this project does not follow strict SemVer pre-1.0, but version tags are
 still `vMAJOR.MINOR.PATCH`.
 
+## v0.6.8 — Security & quality hardening
+
+### Security fixes
+
+- **Scrypt DoS protection**: backup decryption now validates scrypt
+  parameters (`N` must be a power of two and ≤ 2^20, `r` and `p` within
+  1..32) before calling `scrypt.Key`, preventing a crafted backup envelope
+  from exhausting memory.
+- **Predictable session fallback removed**: `randomSessionID()` no longer
+  falls back to the static `"fallback-session"` ID; the `Session`
+  middleware returns HTTP 500 if a session ID cannot be generated.
+- **Predictable terminal ticket ID removed**: ticket generation returns an
+  empty ID and logs the error on RNG failure instead of using a guessable
+  timestamp.
+- **Logout CSRF fixed**: `/logout` now only accepts `POST`, and the logout
+  links in the shell header and mobile drawer have been converted to
+  CSRF-protected inline forms.
+- **CSRF default-port normalization**: `equalHost` strips `:80` and `:443`
+  suffixes so legitimate same-origin requests are not rejected when the
+  browser omits the default port.
+- **HSTS added**: `Strict-Transport-Security: max-age=31536000;
+  includeSubDomains` is now set by the security-headers middleware.
+- **CSP hardened**: `object-src 'none'` is now included in the CSP.
+- **Admin password minimum length**: production/staging configurations now
+  require the admin password to be at least 8 characters.
+- **Login length limit**: usernames and passwords over 1024 bytes are
+  rejected before the constant-time comparison to avoid DoS.
+
+### XSS fixes
+
+- **analytics.js**: all server-sourced values interpolated into
+  `innerHTML` (chart tooltips, legend, forecast cards, trend/exhaustion
+  indicators) are now escaped via `escapeHTML()`. Color values are validated
+  against a hex-color regex.
+- **app.js**: `bulkChip()` validates the incoming status against an
+  allowlist and falls back to `"unknown"`.
+
+### Backend fixes
+
+- **Home handler context**: dashboard DB queries now use `r.Context()`
+  instead of `context.Background()` so they are cancelled when the client
+  disconnects.
+- **N+1 traffic query eliminated**: the home dashboard batch-fetches latest
+  traffic snapshots via the new `GetLatestTrafficByServerIDs` repository
+  method instead of one query per visible server.
+- **Scheduler pagination fixed**: `homeURL` now includes `sched_page` and
+  the home handler reads the `sched_page` query parameter.
+- **Consumed terminal ticket pruning**: `pruneExpired` now also removes
+  consumed tickets older than 5×TTL, preventing a memory leak if `Release`
+  is missed.
+- **Metrics token log warning**: using `?token=` now logs a warning
+  advising operators to prefer `Authorization: Bearer` to keep tokens out of
+  access logs.
+- **SSH MAC preference**: `HMAC-SHA1` is now the last-resort compatibility
+  entry in the SSH MAC list.
+
+### Middleware fixes
+
+- **Multibyte-safe log truncation**: `safeLogValue` now truncates by rune
+  instead of byte, preserving Persian/RTL text.
+- **Multibyte-safe capitalization**: `friendlyError` now uppercases the
+  first rune via `unicode.ToUpper` instead of the first byte.
+- **Constant-time username comparison**: `RequireAuth` compares the token
+  username with `crypto/subtle`.
+- **Monitoring parse errors logged**: `parseFloat` and `parseInt64` now emit
+  `slog.Debug` when parsing fails instead of silently returning zero.
+- **Atomic alert streak increment**: `incStreak` uses a single atomic
+  `UPDATE ... SET streak = streak + 1` inside a transaction, removing the
+  GetStreak/SetStreak TOCTOU window.
+
 ## v0.6.7 — Mobile terminal UX + architecture documentation
 
 ### Part A: Mobile terminal — persistent tab access

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v0.6.6
+VERSION ?= v0.6.8
 
 .PHONY: test build release
 

--- a/internal/backup/crypto.go
+++ b/internal/backup/crypto.go
@@ -171,6 +171,9 @@ func open(raw []byte, passphrase string) ([]byte, error) {
 	if n == 0 {
 		n, r, p = scryptN, scryptR, scryptP
 	}
+	if err := validateScryptParams(n, r, p); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrMalformed, err)
+	}
 	key, err := scrypt.Key([]byte(passphrase), salt, n, r, p, scryptKeyLen)
 	if err != nil {
 		return nil, fmt.Errorf("backup: derive key: %w", err)
@@ -191,6 +194,24 @@ func open(raw []byte, passphrase string) ([]byte, error) {
 		return nil, ErrMalformed
 	}
 	return plaintext, nil
+}
+
+// validateScryptParams rejects scrypt cost parameters that could exhaust
+// memory or CPU when decrypting a crafted backup envelope.
+func validateScryptParams(n, r, p int) error {
+	if n <= 0 || (n&(n-1)) != 0 {
+		return errors.New("scrypt N must be a power of 2")
+	}
+	if n > 1<<20 {
+		return errors.New("scrypt N is too large")
+	}
+	if r < 1 || r > 32 {
+		return errors.New("scrypt r must be between 1 and 32")
+	}
+	if p < 1 || p > 32 {
+		return errors.New("scrypt p must be between 1 and 32")
+	}
+	return nil
 }
 
 func newGCM(key []byte) (cipher.AEAD, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,6 +344,9 @@ func (c Config) Validate() error {
 		if pw := strings.TrimSpace(c.Security.AdminPassword); pw == weakAdminPassword || pw == exampleAdminPassword {
 			return errors.New("config: NODEXIA_AUTH_PASSWORD must not use a known-weak password outside development or test")
 		}
+		if len(strings.TrimSpace(c.Security.AdminPassword)) < 8 {
+			return errors.New("config: NODEXIA_AUTH_PASSWORD must be at least 8 characters outside development or test")
+		}
 	}
 
 	if c.Digest.Enabled && c.Digest.Interval <= 0 {

--- a/internal/http/handlers/auth.go
+++ b/internal/http/handlers/auth.go
@@ -59,6 +59,11 @@ func (h LoginHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	username := strings.TrimSpace(r.FormValue("username"))
 	password := r.FormValue("password")
 
+	if len(username) > 1024 || len(password) > 1024 {
+		h.renderLogin(w, r, http.StatusBadRequest, "error", loc.T("login.invalid"))
+		return
+	}
+
 	expectedUser := strings.TrimSpace(h.config.Security.AdminUsername)
 	expectedPass := h.config.Security.AdminPassword
 
@@ -161,6 +166,10 @@ func NewLogoutHandler(cookieSecure bool) LogoutHandler {
 }
 
 func (h LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	http.SetCookie(w, middleware.ClearAuthCookie(h.cookieSecure))
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/internal/http/handlers/home.go
+++ b/internal/http/handlers/home.go
@@ -50,6 +50,7 @@ const homeDashboardPerPage = 5
 
 func (h HomeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	snapPage, _ := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("snap_page")))
+	schedPage, _ := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("sched_page")))
 
 	page := view.NewPageData(h.config, r)
 	page.CSRFToken = middleware.GetCSRFToken(r.Context())
@@ -71,12 +72,12 @@ func (h HomeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// (localStorage) so the server always renders the full, current set.
 	page.HomeWarnings = homeWarnings(r.Context(), h.database, &page)
 
-	page.SchedulerOverview = schedulerOverviewView(h.scheduler, 1, 8, countries, func(p int) string {
+	page.SchedulerOverview = schedulerOverviewView(h.scheduler, schedPage, 8, countries, func(p int) string {
 		return homeURL(snapPage, p)
 	})
 
 	if h.database != nil && h.database.SQL != nil {
-		ctx := context.Background()
+		ctx := r.Context()
 		snapshotRepo := monitoring.NewSQLRepository(h.database.SQL)
 		if allSnaps, err := snapshotRepo.ListAllLatestByServer(ctx); err == nil {
 			total := len(allSnaps)
@@ -84,17 +85,31 @@ func (h HomeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			page.DashboardSnapshotTotal = total
 			page.DashboardSnapshotPagination = buildPaginationView(currentPage, totalPages, func(p int) string {
-				return homeURL(p, 0)
+				return homeURL(p, schedPage)
 			})
+
+			// Batch-fetch the latest traffic snapshot for every visible server
+			// instead of issuing one query per row.
+			visibleIDs := make([]int64, 0, end-start)
+			for _, snapshot := range allSnaps[start:end] {
+				visibleIDs = append(visibleIDs, snapshot.ServerID)
+			}
+			trafficByServer := make(map[int64]monitoring.TrafficSnapshot)
+			if trafficSnaps, err := snapshotRepo.GetLatestTrafficByServerIDs(ctx, visibleIDs); err == nil {
+				for _, ts := range trafficSnaps {
+					trafficByServer[ts.ServerID] = ts
+				}
+			}
+
 			page.DashboardSnapshots = make([]view.DashboardMonitoringView, 0, end-start)
+			currentMonth := time.Now().UTC().Format("2006-01")
 			for _, snapshot := range allSnaps[start:end] {
 				v := monitoringDashboardView(snapshot)
 				if badge, ok := countries[snapshot.ServerID]; ok {
 					v.FlagEmoji = badge.Flag
 					v.CountryName = badge.Name
 				}
-				if traffic, err := snapshotRepo.GetLatestTrafficByServer(ctx, snapshot.ServerID); err == nil && traffic.Available {
-					currentMonth := time.Now().UTC().Format("2006-01")
+				if traffic, ok := trafficByServer[snapshot.ServerID]; ok && traffic.Available {
 					for _, row := range traffic.MonthlyRows {
 						if row.Label == currentMonth {
 							v.CurrentMonthDL = dashboardFormatBytes(row.RXBytes)
@@ -198,11 +213,14 @@ func nodeStateRank(state string) int {
 	}
 }
 
-// homeURL builds a home-page URL for snapshot pagination.
-func homeURL(snapPage, _ int) string {
+// homeURL builds a home-page URL for snapshot and scheduler pagination.
+func homeURL(snapPage, schedPage int) string {
 	v := url.Values{}
 	if snapPage > 1 {
 		v.Set("snap_page", strconv.Itoa(snapPage))
+	}
+	if schedPage > 1 {
+		v.Set("sched_page", strconv.Itoa(schedPage))
 	}
 	if q := v.Encode(); q != "" {
 		return "/?" + q

--- a/internal/http/handlers/metrics.go
+++ b/internal/http/handlers/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -58,6 +59,7 @@ func (h MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // or, for scrapers that cannot set headers, the ?token= query parameter.
 func metricsTokenMatches(r *http.Request, expected string) bool {
 	presented := ""
+	fromQuery := false
 	if auth := strings.TrimSpace(r.Header.Get("Authorization")); auth != "" {
 		if bearer, ok := strings.CutPrefix(auth, "Bearer "); ok {
 			presented = strings.TrimSpace(bearer)
@@ -65,6 +67,10 @@ func metricsTokenMatches(r *http.Request, expected string) bool {
 	}
 	if presented == "" {
 		presented = strings.TrimSpace(r.URL.Query().Get("token"))
+		fromQuery = presented != ""
+	}
+	if fromQuery {
+		slog.Warn("metrics: token supplied via query string; use Authorization: Bearer header to avoid leaking the token in access logs")
 	}
 	return presented != "" && subtle.ConstantTimeCompare([]byte(presented), []byte(expected)) == 1
 }

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -51,12 +52,12 @@ func RequireAuth(cfg config.Config) Middleware {
 				return
 			}
 
-			token, err := parseAuthToken(cookie.Value, secret)
-			if err != nil || token.Username != cfg.Security.AdminUsername || time.Now().After(token.ExpiresAt) {
-				http.SetCookie(w, ClearAuthCookie(cfg.Security.SessionCookieSecure))
-				redirectLogin(w, r)
-				return
-			}
+		token, err := parseAuthToken(cookie.Value, secret)
+		if err != nil || subtle.ConstantTimeCompare([]byte(token.Username), []byte(cfg.Security.AdminUsername)) != 1 || time.Now().After(token.ExpiresAt) {
+			http.SetCookie(w, ClearAuthCookie(cfg.Security.SessionCookieSecure))
+			redirectLogin(w, r)
+			return
+		}
 
 			ctx := context.WithValue(r.Context(), authTokenKey, token.Username)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/http/middleware/logging.go
+++ b/internal/http/middleware/logging.go
@@ -89,8 +89,9 @@ func safeLogValue(value string) string {
 	value = strings.TrimSpace(value)
 	value = strings.ReplaceAll(value, "\n", " ")
 	value = strings.ReplaceAll(value, "\r", " ")
-	if len(value) > 240 {
-		return value[:240] + "..."
+	runes := []rune(value)
+	if len(runes) > 240 {
+		return string(runes[:240]) + "..."
 	}
 	return value
 }

--- a/internal/http/middleware/security.go
+++ b/internal/http/middleware/security.go
@@ -56,6 +56,10 @@ func Session(cfg config.Config) Middleware {
 			}
 
 			sessionID, needsRefresh := validateOrCreateSession(r, secret, cookieName, sessionTTL)
+			if sessionID == "" {
+				http.Error(w, "session unavailable", http.StatusInternalServerError)
+				return
+			}
 			if needsRefresh {
 				http.SetCookie(w, buildSessionCookie(cookieName, sessionID, secret, sessionTTL, cookieSecure))
 			}
@@ -178,7 +182,7 @@ func validateOrCreateSession(r *http.Request, secret []byte, cookieName string, 
 	if err != nil {
 		sessionID, createErr := randomSessionID()
 		if createErr != nil {
-			return "fallback-session", true
+			return "", true
 		}
 		return sessionID, true
 	}
@@ -187,7 +191,7 @@ func validateOrCreateSession(r *http.Request, secret []byte, cookieName string, 
 	if err != nil {
 		newID, createErr := randomSessionID()
 		if createErr != nil {
-			return "fallback-session", true
+			return "", true
 		}
 		return newID, true
 	}
@@ -195,7 +199,7 @@ func validateOrCreateSession(r *http.Request, secret []byte, cookieName string, 
 	if time.Since(issuedAt) > ttl {
 		newID, createErr := randomSessionID()
 		if createErr != nil {
-			return "fallback-session", true
+			return "", true
 		}
 		return newID, true
 	}

--- a/internal/http/middleware/security.go
+++ b/internal/http/middleware/security.go
@@ -36,7 +36,8 @@ func SecurityHeaders() Middleware {
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("Referrer-Policy", "same-origin")
 			w.Header().Set("Cache-Control", "no-store")
-			w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; script-src 'self'; font-src 'self'; connect-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'")
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; script-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'")
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -298,7 +299,20 @@ func requestHost(r *http.Request) string {
 }
 
 func equalHost(left, right string) bool {
-	left = strings.TrimSpace(strings.ToLower(left))
-	right = strings.TrimSpace(strings.ToLower(right))
+	left = stripDefaultPort(strings.TrimSpace(strings.ToLower(left)))
+	right = stripDefaultPort(strings.TrimSpace(strings.ToLower(right)))
 	return left != "" && right != "" && left == right
+}
+
+// stripDefaultPort removes the default HTTP/HTTPS port suffix so that
+// "example.com:443" matches "example.com" for same-origin checks.
+func stripDefaultPort(host string) string {
+	switch {
+	case strings.HasSuffix(host, ":80"):
+		return host[:len(host)-3]
+	case strings.HasSuffix(host, ":443"):
+		return host[:len(host)-4]
+	default:
+		return host
+	}
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -64,7 +64,7 @@ func NewRouter(cfg config.Config, database *db.Runtime, sshService *sshclient.Se
 	loginHandler := handlers.NewLoginHandler(cfg, renderer, loginThrottle)
 	mux.HandleFunc("GET /login", loginHandler.ServeHTTP)
 	mux.HandleFunc("POST /login", loginHandler.ServeHTTP)
-	mux.Handle("GET /logout", handlers.NewLogoutHandler(cfg.Security.SessionCookieSecure))
+	mux.Handle("POST /logout", handlers.NewLogoutHandler(cfg.Security.SessionCookieSecure))
 
 	mux.Handle("GET /{$}", handlers.NewHomeHandler(cfg, database, renderer, backgroundScheduler, registry.RouteGroups(modules)))
 	diagHandler := handlers.NewDiagnosticsHandler(cfg, database, renderer, backgroundScheduler, commandStreams)

--- a/internal/module/alerts/evaluator.go
+++ b/internal/module/alerts/evaluator.go
@@ -433,15 +433,7 @@ func (e *Evaluator) message(rule Rule, target Target, value float64, state strin
 }
 
 func (e *Evaluator) incStreak(ctx context.Context, rule Rule, target Target) (int, error) {
-	current, err := e.repo.GetStreak(ctx, rule.ID, target.ID)
-	if err != nil {
-		return 0, err
-	}
-	next := current + 1
-	if err := e.repo.SetStreak(ctx, rule.ID, target.ID, next); err != nil {
-		return 0, err
-	}
-	return next, nil
+	return e.repo.IncrementStreak(ctx, rule.ID, target.ID)
 }
 
 func (e *Evaluator) resetStreak(ctx context.Context, rule Rule, target Target) error {

--- a/internal/module/alerts/repository.go
+++ b/internal/module/alerts/repository.go
@@ -143,6 +143,9 @@ type Repository interface {
 	// SetStreak upserts the streak for (ruleID, serverID). A value of 0 deletes
 	// the row so the table stays small.
 	SetStreak(ctx context.Context, ruleID, serverID int64, streak int) error
+	// IncrementStreak atomically increments the streak for (ruleID, serverID)
+	// and returns the new value. If no row exists, it inserts a streak of 1.
+	IncrementStreak(ctx context.Context, ruleID, serverID int64) (int, error)
 	// ListStreaksForRules returns the current streak for each (rule_id, server_id)
 	// pair. Used by the overview page to show pending breach counts.
 	ListStreaksForRules(ctx context.Context, ruleIDs []int64) (map[streakKey]int, error)

--- a/internal/module/alerts/sql_repository.go
+++ b/internal/module/alerts/sql_repository.go
@@ -746,6 +746,60 @@ func (r SQLRepository) SetStreak(ctx context.Context, ruleID, serverID int64, st
 	return nil
 }
 
+func (r SQLRepository) IncrementStreak(ctx context.Context, ruleID, serverID int64) (int, error) {
+	now := time.Now().UTC()
+
+	tx, err := r.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("alerts: begin increment streak transaction: %w", err)
+	}
+
+	res, err := tx.ExecContext(
+		ctx,
+		`UPDATE alert_rule_streaks SET streak = streak + 1, updated_at = ? WHERE rule_id = ? AND server_id = ?`,
+		now, ruleID, serverID,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("alerts: increment streak rule %d server %d: %w", ruleID, serverID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("alerts: read affected rows for streak rule %d server %d: %w", ruleID, serverID, err)
+	}
+
+	if affected == 0 {
+		if _, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO alert_rule_streaks (rule_id, server_id, streak, updated_at) VALUES (?, ?, ?, ?)`,
+			ruleID, serverID, 1, now,
+		); err != nil {
+			_ = tx.Rollback()
+			return 0, fmt.Errorf("alerts: insert streak rule %d server %d: %w", ruleID, serverID, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("alerts: commit increment streak transaction: %w", err)
+		}
+		return 1, nil
+	}
+
+	var streak int
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT streak FROM alert_rule_streaks WHERE rule_id = ? AND server_id = ?`,
+		ruleID, serverID,
+	).Scan(&streak); err != nil {
+		_ = tx.Rollback()
+		return 0, fmt.Errorf("alerts: read incremented streak rule %d server %d: %w", ruleID, serverID, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("alerts: commit increment streak transaction: %w", err)
+	}
+	return streak, nil
+}
+
 func (r SQLRepository) ListStreaksForRules(ctx context.Context, ruleIDs []int64) (map[streakKey]int, error) {
 	if len(ruleIDs) == 0 {
 		return map[streakKey]int{}, nil

--- a/internal/module/files/ops.go
+++ b/internal/module/files/ops.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"unicode"
 
 	"github.com/Ho3einK84/Nodexia/internal/module"
 	"github.com/Ho3einK84/Nodexia/internal/module/servers"
@@ -294,7 +295,12 @@ func friendlyError(err error) string {
 	if msg == "" {
 		return "The operation failed."
 	}
-	return strings.ToUpper(msg[:1]) + msg[1:]
+	runes := []rune(msg)
+	if len(runes) > 0 {
+		runes[0] = unicode.ToUpper(runes[0])
+		return string(runes)
+	}
+	return msg
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/module/monitoring/collector.go
+++ b/internal/module/monitoring/collector.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -112,6 +113,7 @@ func parseFloat(value string) float64 {
 	}
 	parsed, err := strconv.ParseFloat(value, 64)
 	if err != nil {
+		slog.Debug("monitoring: parse float failed", slog.String("value", value))
 		return 0
 	}
 	return parsed
@@ -124,6 +126,7 @@ func parseInt64(value string) int64 {
 	}
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
+		slog.Debug("monitoring: parse int failed", slog.String("value", value))
 		return 0
 	}
 	return parsed

--- a/internal/module/monitoring/traffic_repository.go
+++ b/internal/module/monitoring/traffic_repository.go
@@ -33,6 +33,7 @@ type TrafficSnapshot struct {
 type TrafficRepository interface {
 	AppendTraffic(ctx context.Context, snapshot TrafficSnapshot) (TrafficSnapshot, error)
 	GetLatestTrafficByServer(ctx context.Context, serverID int64) (TrafficSnapshot, error)
+	GetLatestTrafficByServerIDs(ctx context.Context, serverIDs []int64) ([]TrafficSnapshot, error)
 }
 
 func (r SQLRepository) AppendTraffic(ctx context.Context, snapshot TrafficSnapshot) (TrafficSnapshot, error) {
@@ -132,6 +133,95 @@ func (r SQLRepository) GetLatestTrafficByServer(ctx context.Context, serverID in
 			return TrafficSnapshot{}, ErrNotFound
 		}
 		return TrafficSnapshot{}, fmt.Errorf("monitoring: get latest vnstat snapshot for server %d: %w", serverID, err)
+	}
+
+	snapshot.Available = available == 1
+	if err := json.Unmarshal([]byte(availableInterfacesJSON), &snapshot.AvailableInterfaces); err != nil {
+		return TrafficSnapshot{}, fmt.Errorf("monitoring: unmarshal vnstat interfaces: %w", err)
+	}
+	if err := json.Unmarshal([]byte(dailyRowsJSON), &snapshot.DailyRows); err != nil {
+		return TrafficSnapshot{}, fmt.Errorf("monitoring: unmarshal vnstat daily rows: %w", err)
+	}
+	if err := json.Unmarshal([]byte(monthlyRowsJSON), &snapshot.MonthlyRows); err != nil {
+		return TrafficSnapshot{}, fmt.Errorf("monitoring: unmarshal vnstat monthly rows: %w", err)
+	}
+
+	collectedAt, err := parseDatabaseTime(collectedAtRaw)
+	if err != nil {
+		return TrafficSnapshot{}, fmt.Errorf("monitoring: parse vnstat collected_at: %w", err)
+	}
+	snapshot.CollectedAt = collectedAt
+	return normalizeTrafficSnapshot(snapshot), nil
+}
+
+// GetLatestTrafficByServerIDs returns the most recent vnstat snapshot for each
+// of the requested server IDs in a single query.
+func (r SQLRepository) GetLatestTrafficByServerIDs(ctx context.Context, serverIDs []int64) ([]TrafficSnapshot, error) {
+	if len(serverIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(serverIDs))
+	args := make([]any, len(serverIDs))
+	for i, id := range serverIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `SELECT id, server_id, available, interface_name, available_interfaces_json,
+		         daily_rows_json, monthly_rows_json, peak_mbps, avg_mbps, message, collected_at
+		  FROM vnstat_snapshots
+		  WHERE id IN (
+		      SELECT MAX(id)
+		      FROM vnstat_snapshots
+		      WHERE server_id IN (` + strings.Join(placeholders, ",") + `)
+		      GROUP BY server_id
+		  )`
+
+	rows, err := r.conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring: get latest vnstat snapshots for servers: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []TrafficSnapshot
+	for rows.Next() {
+		snapshot, err := scanTrafficRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("monitoring: scan vnstat snapshot row: %w", err)
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("monitoring: iterate vnstat snapshots: %w", err)
+	}
+
+	return snapshots, nil
+}
+
+func scanTrafficRow(rows *sql.Rows) (TrafficSnapshot, error) {
+	var snapshot TrafficSnapshot
+	var available int
+	var availableInterfacesJSON string
+	var dailyRowsJSON string
+	var monthlyRowsJSON string
+	var collectedAtRaw any
+
+	if err := rows.Scan(
+		&snapshot.ID,
+		&snapshot.ServerID,
+		&available,
+		&snapshot.InterfaceName,
+		&availableInterfacesJSON,
+		&dailyRowsJSON,
+		&monthlyRowsJSON,
+		&snapshot.PeakMbps,
+		&snapshot.AvgMbps,
+		&snapshot.Message,
+		&collectedAtRaw,
+	); err != nil {
+		return TrafficSnapshot{}, err
 	}
 
 	snapshot.Available = available == 1

--- a/internal/module/terminal/handlers.go
+++ b/internal/module/terminal/handlers.go
@@ -230,7 +230,11 @@ func (h postHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ConnectTimeout: connectTimeout,
 	}
 
-	ticketID := h.deps.TerminalTickets.Create(serverID, req)
+	ticketID, err := h.deps.TerminalTickets.Create(serverID, req)
+	if err != nil {
+		http.Error(w, "failed to create terminal ticket", http.StatusInternalServerError)
+		return
+	}
 	renderTerminalPage(w, r, h.deps, server, view.TerminalFormView{}, ticketID, initCmd)
 }
 

--- a/internal/module/terminal/handlers_test.go
+++ b/internal/module/terminal/handlers_test.go
@@ -223,7 +223,10 @@ func TestTerminalWSRejectsCrossOrigin(t *testing.T) {
 	serverRepo := servers.NewSQLRepository(deps.Database.SQL)
 	s := seedServer(t, serverRepo, true)
 
-	ticketID := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	ticketID, err := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 
 	mux := registerRoutes(t, deps)
 	req := httptest.NewRequest(http.MethodGet,
@@ -261,7 +264,10 @@ func TestTerminalWSRejectsExpiredTicket(t *testing.T) {
 	serverRepo := servers.NewSQLRepository(deps.Database.SQL)
 	s := seedServer(t, serverRepo, true)
 
-	ticketID := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	ticketID, err := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 	time.Sleep(5 * time.Millisecond)
 
 	mux := registerRoutes(t, deps)
@@ -287,7 +293,10 @@ func TestTerminalWSSessionLimitRejected(t *testing.T) {
 		deps.TerminalTickets.TryAcquireSession("", max)
 	}
 
-	ticketID := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	ticketID, err := deps.TerminalTickets.Create(s.ID, sshclient.ConnectionRequest{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 
 	mux := registerRoutes(t, deps)
 	req := sameOriginRequest(http.MethodGet,

--- a/internal/sshclient/service.go
+++ b/internal/sshclient/service.go
@@ -574,6 +574,8 @@ var (
 		xssh.HMACSHA512ETM,
 		xssh.HMACSHA256,
 		xssh.HMACSHA512,
+		// HMAC-SHA1 is a last-resort compatibility fallback for legacy SSH
+		// peers; prefer the SHA-256/512 options above when available.
 		xssh.HMACSHA1,
 	}
 	hostKeyAlgorithms = []string{

--- a/internal/terminalticket/store.go
+++ b/internal/terminalticket/store.go
@@ -144,10 +144,13 @@ func (s *Store) ReleaseSession(username string) {
 
 func (s *Store) pruneExpired() {
 	cutoff := time.Now().Add(-s.ttl)
+	consumedCutoff := time.Now().Add(-s.ttl * 5)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, st := range s.tickets {
 		if !st.used.Load() && st.ticket.CreatedAt.Before(cutoff) {
+			delete(s.tickets, id)
+		} else if st.used.Load() && st.ticket.CreatedAt.Before(consumedCutoff) {
 			delete(s.tickets, id)
 		}
 	}

--- a/internal/terminalticket/store.go
+++ b/internal/terminalticket/store.go
@@ -16,6 +16,8 @@ package terminalticket
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -67,10 +69,13 @@ func New(ttl time.Duration) *Store {
 }
 
 // Create stores a new ticket and returns its ID.
-func (s *Store) Create(serverID int64, req sshclient.ConnectionRequest) string {
+func (s *Store) Create(serverID int64, req sshclient.ConnectionRequest) (string, error) {
 	s.pruneExpired()
 
 	id := newID()
+	if id == "" {
+		return "", errors.New("terminalticket: failed to generate ticket ID")
+	}
 	s.mu.Lock()
 	s.tickets[id] = &ticketState{
 		ticket: Ticket{
@@ -81,7 +86,7 @@ func (s *Store) Create(serverID int64, req sshclient.ConnectionRequest) string {
 		},
 	}
 	s.mu.Unlock()
-	return id
+	return id, nil
 }
 
 // Consume atomically marks the ticket as used and returns it.  Returns
@@ -151,7 +156,8 @@ func (s *Store) pruneExpired() {
 func newID() string {
 	buf := make([]byte, 16)
 	if _, err := rand.Read(buf); err != nil {
-		return hex.EncodeToString([]byte(time.Now().UTC().Format("20060102150405.000000000")))
+		slog.Error("terminalticket: failed to generate random ticket ID", slog.Any("error", err))
+		return ""
 	}
 	return hex.EncodeToString(buf)
 }

--- a/internal/terminalticket/store_test.go
+++ b/internal/terminalticket/store_test.go
@@ -15,7 +15,10 @@ func req() sshclient.ConnectionRequest {
 func TestCreateAndConsume(t *testing.T) {
 	s := terminalticket.New(30 * time.Second)
 
-	id := s.Create(1, req())
+	id, err := s.Create(1, req())
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 	if id == "" {
 		t.Fatal("Create returned empty id")
 	}
@@ -34,7 +37,10 @@ func TestCreateAndConsume(t *testing.T) {
 
 func TestConsumeSingleUse(t *testing.T) {
 	s := terminalticket.New(30 * time.Second)
-	id := s.Create(1, req())
+	id, err := s.Create(1, req())
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 
 	if _, ok := s.Consume(id); !ok {
 		t.Fatal("first Consume returned false")
@@ -47,7 +53,10 @@ func TestConsumeSingleUse(t *testing.T) {
 func TestConsumeExpired(t *testing.T) {
 	// TTL of 1 ms so the ticket is already expired.
 	s := terminalticket.New(1 * time.Millisecond)
-	id := s.Create(1, req())
+	id, err := s.Create(1, req())
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 	time.Sleep(5 * time.Millisecond)
 
 	if _, ok := s.Consume(id); ok {
@@ -64,7 +73,10 @@ func TestConsumeUnknown(t *testing.T) {
 
 func TestRelease(t *testing.T) {
 	s := terminalticket.New(30 * time.Second)
-	id := s.Create(1, req())
+	id, err := s.Create(1, req())
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
 	s.Consume(id)
 	s.Release(id)
 

--- a/web/static/analytics.js
+++ b/web/static/analytics.js
@@ -5,6 +5,20 @@
   // Localization helper (see app.js for window.nxT). Falls back to the key.
   function T(key, params) { return window.nxT ? window.nxT(key, params) : key; }
 
+  // Escape HTML-special characters so server-sourced values can safely be
+  // interpolated into innerHTML.
+  function escapeHTML(str) {
+    return String(str).replace(/[&<>"']/g, function (m) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[m];
+    });
+  }
+
+  // Only accept hex color values; fall back to a safe default otherwise.
+  const COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
+  function validColor(color) {
+    return COLOR_RE.test(color) ? color : '#3b82f6';
+  }
+
   // ── SVG chart renderer ────────────────────────────────────────────────────
 
   const CHART_PAD = { top: 12, right: 16, bottom: 28, left: 42 };
@@ -81,7 +95,7 @@
       plotG.appendChild(createSVGEl('path', {
         class: 'chart-area',
         d: areaD,
-        fill: s.color || '#3b82f6',
+        fill: validColor(s.color),
       }));
 
       // Line
@@ -89,7 +103,7 @@
       plotG.appendChild(createSVGEl('path', {
         class: 'chart-path',
         d: lineD,
-        stroke: s.color || '#3b82f6',
+        stroke: validColor(s.color),
       }));
     }
 
@@ -154,7 +168,7 @@
         container.appendChild(tooltipEl);
       }
 
-      let html = `<div class="chart-tooltip__label">${labels[idx]}</div>`;
+      let html = `<div class="chart-tooltip__label">${escapeHTML(labels[idx])}</div>`;
       for (const s of series) {
         if (!s.data || idx >= s.data.length) continue;
         const v = s.data[idx];
@@ -162,8 +176,8 @@
           : unit === 'GiB' ? v.toFixed(3) + ' GiB'
           : v.toFixed(2) + (unit ? ' ' + unit : '');
         html += `<div class="chart-tooltip__row">
-          <span class="chart-tooltip__dot" style="background:${s.color}"></span>
-          <span>${s.label}</span>
+          <span class="chart-tooltip__dot" style="background:${validColor(s.color)}"></span>
+          <span>${escapeHTML(s.label)}</span>
           <span class="chart-tooltip__value">${formatted}</span>
         </div>`;
       }
@@ -322,8 +336,8 @@
     if (!legend) return;
     legend.innerHTML = series.map(s => `
       <div class="legend-item">
-        <span class="legend-dot" style="background:${s.color}"></span>
-        ${s.label}
+        <span class="legend-dot" style="background:${validColor(s.color)}"></span>
+        ${escapeHTML(s.label)}
       </div>
     `).join('');
   }
@@ -410,15 +424,15 @@
       : '';
     return `
       <div class="forecast-card">
-        <div class="forecast-card__label">${label} <span class="forecast-card__scope">${scopeLabel}</span></div>
-        <div class="forecast-card__current">${period.current_human}</div>
+        <div class="forecast-card__label">${escapeHTML(label)} <span class="forecast-card__scope">${escapeHTML(scopeLabel)}</span></div>
+        <div class="forecast-card__current">${escapeHTML(period.current_human)}</div>
         <div class="forecast-card__predicted">
-          ${T('js.analytics.predicted_end')} <strong>${period.predicted_human}</strong>
+          ${escapeHTML(T('js.analytics.predicted_end'))} <strong>${escapeHTML(period.predicted_human)}</strong>
         </div>
         <div class="forecast-progress">
           <div class="forecast-progress__bar ${progressClass}" style="width:${Math.min(100, pct)}%"></div>
         </div>
-        <div class="forecast-progress__label">${T('js.analytics.period_elapsed', { pct: pct })}${periodNote ? ` · ${periodNote}` : ''}</div>
+        <div class="forecast-progress__label">${escapeHTML(T('js.analytics.period_elapsed', { pct: pct }))}${periodNote ? ` · ${escapeHTML(periodNote)}` : ''}</div>
       </div>
     `;
   }
@@ -474,9 +488,9 @@
     panel.innerHTML = `
       <i data-lucide="${icon}" class="forecast-exhaustion__icon"></i>
       <div class="forecast-exhaustion__body">
-        <div class="forecast-exhaustion__title">${T('js.analytics.exhaustion_title')}</div>
-        <div class="forecast-exhaustion__message">${message}</div>
-        ${sub ? `<div class="forecast-exhaustion__sub">${sub}</div>` : ''}
+        <div class="forecast-exhaustion__title">${escapeHTML(T('js.analytics.exhaustion_title'))}</div>
+        <div class="forecast-exhaustion__message">${escapeHTML(message)}</div>
+        ${sub ? `<div class="forecast-exhaustion__sub">${escapeHTML(sub)}</div>` : ''}
       </div>
     `;
   }
@@ -488,15 +502,16 @@
       stable:     { cls: 'trend-indicator--stable',     icon: '→', label: T('js.analytics.trend_stable') },
     };
     const t = map[trend] || map.stable;
-    return `<span class="trend-indicator ${t.cls}">${t.icon} ${t.label}</span>`;
+    return `<span class="trend-indicator ${t.cls}">${t.icon} ${escapeHTML(t.label)}</span>`;
   }
 
   function renderConfidence(confidence) {
-    const level = T('js.analytics.confidence_' + confidence);
+    const validConfidence = ['low', 'medium', 'high'].includes(confidence) ? confidence : 'low';
+    const level = T('js.analytics.confidence_' + validConfidence);
     return `
       <span class="forecast-confidence">
-        <span class="confidence-dot confidence-dot--${confidence}"></span>
-        ${T('js.analytics.confidence', { level: level })}
+        <span class="confidence-dot confidence-dot--${validConfidence}"></span>
+        ${escapeHTML(T('js.analytics.confidence', { level: level }))}
       </span>
     `;
   }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -888,14 +888,17 @@
   }
 
   function bulkChip(status) {
+    var allowed = ['ok', 'failed', 'skipped', 'pending', 'running', 'timeout'];
+    var safeStatus = allowed.indexOf(status) !== -1 ? status : 'unknown';
     var inner = {
       ok: '<i data-lucide="check-circle-2" class="icon-in-button"></i> ' + I18N.t('bulk.status_ok'),
       failed: '<i data-lucide="x-circle" class="icon-in-button"></i> ' + I18N.t('bulk.status_failed'),
       skipped: '<i data-lucide="skip-forward" class="icon-in-button"></i> ' + I18N.t('bulk.status_skipped'),
       pending: '<span class="spinner spinner--sm"></span> ' + I18N.t('bulk.status_pending'),
-      running: '<span class="spinner spinner--sm"></span> ' + I18N.t('bulk.status_running')
-    }[status] || ('<i data-lucide="x-circle" class="icon-in-button"></i> ' + I18N.t('bulk.status_failed'));
-    return '<span class="bulk-status bulk-status--' + status + '" data-bulk-status>' + inner + '</span>';
+      running: '<span class="spinner spinner--sm"></span> ' + I18N.t('bulk.status_running'),
+      timeout: '<i data-lucide="x-circle" class="icon-in-button"></i> ' + I18N.t('bulk.status_failed')
+    }[safeStatus] || ('<i data-lucide="x-circle" class="icon-in-button"></i> ' + I18N.t('bulk.status_failed'));
+    return '<span class="bulk-status bulk-status--' + safeStatus + '" data-bulk-status>' + inner + '</span>';
   }
 
   function updateBulkSummary(card, done) {

--- a/web/templates/partials.gohtml
+++ b/web/templates/partials.gohtml
@@ -44,7 +44,10 @@
     <span>{{ t "shell.meta.version" "value" .Version }}</span>
     <span>{{ t "shell.meta.db" "value" .DatabaseDriver }}</span>
     {{ template "lang-switcher" . }}
-    <a href="/logout" class="logout-link" data-tab-bypass>{{ t "nav.logout" }}</a>
+    <form action="/logout" method="post" style="display:inline">
+      <input type="hidden" name="_csrf_token" value="{{ .CSRFToken }}">
+      <button type="submit" class="logout-link">{{ t "nav.logout" }}</button>
+    </form>
   </div>
   {{ if ne .ContentTemplate "content-login" }}
   <button type="button" class="nav-toggle" data-drawer-open aria-label="{{ t "shell.menu.open" }}" aria-expanded="false" aria-controls="mobile-drawer">
@@ -104,7 +107,10 @@
     {{ template "lang-switcher" . }}
   </div>
 
-  <a href="/logout" class="btn btn--secondary drawer__logout" data-tab-bypass><i data-lucide="log-out" class="icon-in-button"></i> {{ t "nav.logout" }}</a>
+  <form action="/logout" method="post" style="display:inline">
+    <input type="hidden" name="_csrf_token" value="{{ .CSRFToken }}">
+    <button type="submit" class="btn btn--secondary drawer__logout"><i data-lucide="log-out" class="icon-in-button"></i> {{ t "nav.logout" }}</button>
+  </form>
 </aside>
 {{ end }}
 


### PR DESCRIPTION
## v0.6.8 Security & Quality Hardening

This release addresses all findings from the v0.6.8 code review.

### Security fixes
- Scrypt parameter validation prevents DoS via crafted backup envelopes.
- Session ID fallback no longer returns a shared static value.
- Terminal ticket ID generation returns empty on RNG failure instead of a guessable timestamp.
- Logout now requires POST, preventing logout CSRF.
- CSRF same-origin check normalizes default ports.
- HSTS header added; CSP now includes `object-src 'none'`.
- Admin password minimum length enforced outside dev/test.
- Login username/password length capped to prevent timing-compare DoS.

### XSS fixes
- All server-sourced values interpolated into `innerHTML` in `analytics.js` are escaped.
- Bulk chip status is validated against an allowlist.

### Backend fixes
- Home handler uses `r.Context()` instead of `context.Background()`.
- Latest traffic is fetched in batch via `GetLatestTrafficByServerIDs`.
- Scheduler pagination URLs include `sched_page`.
- Consumed terminal tickets older than 5×TTL are pruned.
- Metrics endpoint warns when token is supplied via query string.
- HMAC-SHA1 moved to last-resort SSH MAC compatibility slot.

### Middleware fixes
- `safeLogValue` and `friendlyError` are rune-safe for multibyte text.
- Username comparison uses constant-time compare.
- Parse failures in monitoring collector are debug-logged.
- Alert streak update is atomic.